### PR TITLE
Add GCP platform deployment and test support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,15 @@
 ## Overview
 The repo is used to deploy and test the Submariner addon in ACM environment.
 
-## Run
-Execution of deployment and testing requires connection details of the ACM HUB cluster.
+## Prerequisites
+**Note** - Execution of Submariner addon deployment and testing, requires the following:
+* Pre installed ACM Hub cluster
+* At least two managed clusters deployed by the ACM cluster
+
+**Note** - If any requirement is missing, the test flow will fail with relevant message.
+
+## Execute
+Execution of deployment and testing requires connection details of the ACM HUB cluster.  
 The details should be provided as environment variables.
 
 The script could deploy and test all at once or separate the stages.
@@ -36,7 +43,56 @@ export OC_CLUSTER_PASS=<password of the cluster user>
 ./run.sh --test
 ```
 
-## Prerequisites
-**Note** - Execution of Submariner addon deployment and testing, requires the following:
-* Pre installed ACM Hub cluster
-* At least two managed clusters deployed by the ACM cluster
+## Testing platforms
+The following clusters platforms are supported by the Submariner Addon deployment and test:
+- [X] AWS
+- [X] GCP
+- [ ] Azure
+- [ ] VMware
+- [ ] OSP
+
+The user is able to define manually which platforms should be deployed and tested.
+
+```bash
+export OC_CLUSTER_URL=<hub cluster url>
+export OC_CLUSTER_USER=<cluster user name (kubeadmin)>
+export OC_CLUSTER_PASS=<password of the cluster user>
+
+./run.sh --all --platform gcp
+```
+
+Default - aws and gcp.  
+Multiple platforms should be separated by comma:
+
+```bash
+./run.sh --test --platform aws,gcp
+```
+
+Provided platform will be searched and tested.  
+If one of the provided platforms does not exist, deployment and test will continue  
+with the existing platforms, but after the tests execution, the flow will fail with  
+an error message that one of the requested platforms was not found.
+
+## Tests
+Submariner addon testing performed by using the `subctl` command.  
+The tools will be downloaded during the testing to the executors machine.
+
+The following test phases will be done:
+
+| Command                                  | Description                                                                               |
+| ---------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `subctl show all`                        | Shows the aggregated information of versions, networks, gateways, connections, endpoints  |
+| `subctl diagnose all`                    | Execute diagnostic checks to find possible issues or misconfigurations                    |
+| `subctl diagnose firewall inter-cluster` | Checks if the firewall configuration allows tunnels to be configured on the Gateway nodes |
+| `subctl verify`                          | Execute E2E tests to verify proper Submariner functionality                               |
+
+For more information refer to the Submariner documentation - https://submariner.io/operations/deployment/subctl/
+
+**Note** - The `subctl` tool is able to perform testing between two clusters only at the same time.  
+In case multiple clusters exist under the ACM Hub management, the testing step will perform the following flow:  
+* First cluster will be defined as the main cluster for the testing.
+* All other clusters will be looped and tested against the "main" testing cluster.
+
+All the testing information, in additional to the `kubeconfig` files of the managed clusters  
+will be saved on the executors machine in a directory called `tests_logs`,  
+which will be created during tests execution.

--- a/lib/acm_prepare_for_submariner.sh
+++ b/lib/acm_prepare_for_submariner.sh
@@ -1,23 +1,6 @@
 #!/bin/bash
 
-# Check and configure ACM resources as preparation for Submariner Add on install.
-
-# Check if managed clusters assigned to ACM hub.
-function check_managed_clusters() {
-    local clusters_count
-
-    # Exclude the "hub" cluster based of the labels "local-cluster" key.
-    MANAGED_CLUSTERS=$(oc get managedclusters '--selector=name!=local-cluster' \
-                         --no-headers=true -o custom-columns=NAME:.metadata.name)
-    clusters_count=$(echo "$MANAGED_CLUSTERS" | wc -w)
-
-    if [[ "$clusters_count" -lt 2 ]]; then
-        ERROR "At least two managed clusters required for Submariner deployment. Found - $clusters_count"
-    fi
-
-    INFO "Found the following managed clusters:"
-    INFO "$MANAGED_CLUSTERS"
-}
+# Configure ACM resources as preparation for Submariner Add on install.
 
 function create_clusterset() {
     yq eval '.metadata.name = env(CLUSTERSET)' \
@@ -46,5 +29,5 @@ function assign_clusters_to_clusterset() {
     if [[ "$MANAGED_CLUSTERS" != "$assigned_clusters" ]]; then
         ERROR "Failed to assign managed clusters to HUB. Assigned: $assigned_clusters"
     fi
-    INFO "Managed clusters have been assigned to the HUB. Assigned: $assigned_clusters"
+    INFO "Clusters have been assigned to the clusterset $CLUSTERSET. Assigned: $assigned_clusters"
 }

--- a/lib/helper_functions.sh
+++ b/lib/helper_functions.sh
@@ -29,16 +29,27 @@ function ERROR() {
 }
 
 function usage() {
-    echo
-    echo "Deploy Submariner Addon on ACM hub"
-    echo "Requirements:"
-    echo "- ACM hub ready"
-    echo "- At least two managed clusters"
-    echo
-    echo "Arguments:"
-    echo "--all      - Perform deployment and testing of the Submariner addon"
-    echo "--deploy   - Perform deployment of the Submariner addon"
-    echo "--test     - Perform testing of the Submariner addon"
-    echo "--help     - Print help"
-    echo
+    cat <<EOF
+
+    Deploy and test Submariner Addon on ACM hub
+    The script supports the following platforms - AWS, GCP
+
+    Requirements:
+    - ACM hub ready
+    - At least two managed clusters
+
+    Arguments:
+    --all      - Perform deployment and testing of the Submariner addon
+
+    --deploy   - Perform deployment of the Submariner addon
+
+    --test     - Perform testing of the Submariner addon
+
+    --platform - Specify the platforms that should be used for testing
+                 Separate multiple platforms by comma
+                 (Optional)
+                 By default - aws,gcp
+
+    --help|-h  - Print help
+EOF
 }

--- a/lib/submariner_deploy.sh
+++ b/lib/submariner_deploy.sh
@@ -114,6 +114,6 @@ function wait_for_submariner_ready_state() {
         done
         INFO "Submariner connectivity has been established on $cluster cluster"
     done
-    INFO "Submariner connectivity have been sucesfully established between clusters"
-    INFO "All Submariner services sucesfully running on the clusters"
+    INFO "Submariner connectivity have been successfully established between clusters"
+    INFO "All Submariner services successfully running on the clusters"
 }

--- a/lib/validate_acm_readiness.sh
+++ b/lib/validate_acm_readiness.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# Validate ACM Hub is ready for the Submariner addon install and test requirements.
+
+# The function will verify that the platform (aws, gcp, etc...)
+# provided by the user or default is within the supported platforms of the script
+function check_requested_platforms() {
+    INFO "Validate given 'platforms' argument"
+    for provider in $(echo "$PLATFORM" | tr ',' ' '); do
+        if [[ "$SUPPORTED_PLATFORMS" != *"$provider"* ]]; then
+            ERROR "Script supports the following platforms - $SUPPORTED_PLATFORMS. Given - $PLATFORM"
+        fi
+    done
+    INFO "The following platforms requested for testing - $PLATFORM"
+}
+
+# The function will search for available clusters
+# based on the requested platforms - aws, gcp, etc...
+# If one of the requested platforms will not be found,
+# the deployment and test flow will continue, but at the end
+# of script execution, a failure will be raise and noted that
+# requested plafrom was not found.
+function get_available_platforms() {
+    INFO "Fetch existing clusters platforms"
+    local clusters_platforms
+
+    clusters_platforms=$(oc get clusterdeployment -A \
+                           --selector "hive.openshift.io/cluster-platform in ($PLATFORM)" \
+                           --no-headers=true \
+                           -o custom-columns=PLATFORM:".metadata.labels.hive\.openshift\.io/cluster-platform")
+    clusters_platforms=$(echo "$clusters_platforms" | uniq)
+
+    for provider in $(echo "$PLATFORM" | tr ',' ' '); do
+        if [[ "$clusters_platforms" != *"$provider"* ]]; then
+            WARNING "Requested platform - $provider, not in existing cluster platforms - $clusters_platforms"
+            FAILURES+="Platform $provider requested, but not found!"
+        fi
+    done
+    INFO "Existing clusters using the following platform - $PLATFORM"
+}
+
+# Check if cluster deployment exists in ACM
+function check_clusters_deployment() {
+    local clusters_count
+
+    check_requested_platforms
+    get_available_platforms
+
+    MANAGED_CLUSTERS=$(oc get clusterdeployment -A \
+                         --selector "hive.openshift.io/cluster-platform in ($PLATFORM)" \
+                         --no-headers=true -o custom-columns=NAME:.metadata.name)
+    clusters_count=$(echo "$MANAGED_CLUSTERS" | wc -w)
+
+    if [[ "$clusters_count" -lt 2 ]]; then
+        ERROR "At least two managed clusters required for Submariner deployment. Found - $clusters_count"
+    fi
+
+    INFO "Found the following managed clusters:"
+    INFO "$MANAGED_CLUSTERS"
+}

--- a/run.sh
+++ b/run.sh
@@ -9,6 +9,13 @@ export CLUSTERSET="submariner"
 export MANAGED_CLUSTERS=""
 export TESTS_LOGS="$SCRIPT_DIR/tests_logs"
 export SUBCTL_URL_DOWNLOAD="https://github.com/submariner-io/releases/releases"
+export PLATFORM="aws,gcp"  # Default platform definition
+export SUPPORTED_PLATFORMS="aws,gcp"  # Supported platform definition
+# Non critial failures will be stored into the variable
+# and printed at the end of the execution.
+# The testing will be performed,
+# but the failure of the final result will be set.
+export FAILURES=""
 
 # Import functions
 # shellcheck disable=SC1091
@@ -16,7 +23,9 @@ source "${SCRIPT_DIR}/lib/helper_functions.sh"
 # shellcheck disable=SC1091
 source "${SCRIPT_DIR}/lib/prerequisites.sh"
 # shellcheck disable=SC1091
-source "${SCRIPT_DIR}/lib/acm_prepare.sh"
+source "${SCRIPT_DIR}/lib/validate_acm_readiness.sh"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/lib/acm_prepare_for_submariner.sh"
 # shellcheck disable=SC1091
 source "${SCRIPT_DIR}/lib/submariner_deploy.sh"
 # shellcheck disable=SC1091
@@ -36,7 +45,7 @@ function prepare() {
 
     oc login --insecure-skip-tls-verify -u "$OC_CLUSTER_USER" -p "$OC_CLUSTER_PASS" "$OC_CLUSTER_URL"
 
-    check_managed_clusters
+    check_clusters_deployment
 }
 
 function deploy_submariner() {
@@ -54,27 +63,74 @@ function test_submariner() {
     execute_submariner_tests
 }
 
+function finalize() {
+    if  [[ -n "$FAILURES" ]]; then
+        ERROR "Execution finished, but the following failures detected: $FAILURES"
+    fi
+}
 
-case "$1" in
-    --all)
-        prepare
-        deploy_submariner
-        test_submariner
-        ;;
-    --deploy)
-        prepare
-        deploy_submariner
-        ;;
-    --test)
-        prepare
-        test_submariner
-        ;;
-    --help|-h)
-        usage
-        ;;
-    *)
-        echo "Invalid argument provided: $1"
-        usage
-        exit 1
-        ;;
-esac
+function parse_arguments() {
+    while [[ "$#" -gt 0 ]]; do
+        case "$1" in
+            --all)
+                RUN_COMMAND="all"
+                shift
+                ;;
+            --deploy)
+                RUN_COMMAND="deploy"
+                shift
+                ;;
+            --test)
+                RUN_COMMAND="test"
+                shift
+                ;;
+            --platform)
+                if [ -n "$2" ]; then
+                    PLATFORM="$2"
+                    shift 2
+                fi
+                ;;
+            --help|-h)
+                usage
+                ;;
+            *)
+                echo "Invalid argument provided: $1"
+                usage
+                exit 1
+                ;;
+        esac
+    done
+}
+
+
+function main() {
+    RUN_COMMAND=all
+    parse_arguments "$@"
+
+    case "$RUN_COMMAND" in
+        all)
+            prepare
+            deploy_submariner
+            test_submariner
+            finalize
+            ;;
+        deploy)
+            prepare
+            deploy_submariner
+            finalize
+            ;;
+        test)
+            prepare
+            test_submariner
+            finalize
+            ;;
+        *)
+            echo "Invalid command given: $RUN_COMMAND"
+            usage
+            exit 1
+            ;;
+    esac
+}
+
+# Trigger main function
+main "$@"


### PR DESCRIPTION
- Add GCP platform support.
  Currently, deploy and test flow will support AWS and GCP platforms.
- When multiple clusters exists, testing will be performed on all of the
  clusters in the following format:
  First cluster will be tested against each other cluster in a loo
  manner.
- Add parse_argument function to set the proper platform arg definition
- Add check and validation of provided platform argument
- Move check acm readiness functions to a separate file
- Update usage (help) function
- Fix typos