### PR TITLE
Fix prerequisites install steps

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,9 @@ pipeline {
             args '--network host -u 0:0'
         }
     }
+    options {
+        ansiColor('xterm')
+    }
     parameters {
         string(name: 'OC_CLUSTER_URL', defaultValue: '', description: 'ACM Hub API URL')
         string(name: 'OC_CLUSTER_USER', defaultValue: 'kubeadmin', description: 'ACM Hub username')


### PR DESCRIPTION
- Update oc command install condition
  Check the oc command as the only and main command instead of both oc and
  kubectl. If it does not exist, install it.
- Fix subctl client conditions and version definition install.
- Add wget flag to hide long download output.
- Update the link to the openshift client tools
- Add "ansiColor" option to the Jenkinsfile