### PR TITLE
Move fetch kubeconfig function

### DIFF
--- a/lib/helper_functions.sh
+++ b/lib/helper_functions.sh
@@ -58,3 +58,24 @@ function usage() {
     --help|-h  - Print help
 EOF
 }
+
+# Prepare kubeconfig of the managed clusters by fetching them from the hub
+function fetch_kubeconfig_contexts() {
+    INFO "Fetch kubeconfig for managed clusters"
+    local kubeconfig_name
+
+    rm -rf "$TESTS_LOGS"
+    mkdir -p "$TESTS_LOGS"
+
+    for cluster in $MANAGED_CLUSTERS; do
+        kubeconfig_name=$(oc get -n "$cluster" secrets --no-headers \
+                            -o custom-columns=NAME:.metadata.name | grep kubeconfig)
+        oc get secrets "$kubeconfig_name" -n "$cluster" \
+            --template='{{.data.kubeconfig}}' | base64 -d > "$TESTS_LOGS/$cluster-kubeconfig.yaml"
+
+        CL="$cluster" yq eval -i '.contexts[].context.user = env(CL)
+            | .contexts[].name = env(CL)
+            | .current-context = env(CL)
+            | .users[].name = env(CL)' "$TESTS_LOGS/$cluster-kubeconfig.yaml"
+    done
+}

--- a/lib/submariner_test.sh
+++ b/lib/submariner_test.sh
@@ -2,26 +2,6 @@
 
 # Perform Submariner test by using the "subctl" command.
 
-function fetch_kubeconfig_contexts() {
-    INFO "Fetch kubeconfig for managed clusters"
-    local kubeconfig_name
-
-    rm -rf "$TESTS_LOGS"
-    mkdir -p "$TESTS_LOGS"
-
-    for cluster in $MANAGED_CLUSTERS; do
-        kubeconfig_name=$(oc get -n "$cluster" secrets --no-headers \
-                            -o custom-columns=NAME:.metadata.name | grep kubeconfig)
-        oc get secrets "$kubeconfig_name" -n "$cluster" \
-            --template='{{.data.kubeconfig}}' | base64 -d > "$TESTS_LOGS/$cluster-kubeconfig.yaml"
-
-        CL="$cluster" yq eval -i '.contexts[].context.user = env(CL)
-            | .contexts[].name = env(CL)
-            | .current-context = env(CL)
-            | .users[].name = env(CL)' "$TESTS_LOGS/$cluster-kubeconfig.yaml"
-    done
-}
-
 # The function executes Submariner E2E tests by using the subctl tool.
 # The subctl tool is able to run E2E tests only on two clusters
 # at the same time.

--- a/run.sh
+++ b/run.sh
@@ -46,6 +46,7 @@ function prepare() {
     oc login --insecure-skip-tls-verify -u "$OC_CLUSTER_USER" -p "$OC_CLUSTER_PASS" "$OC_CLUSTER_URL"
 
     check_clusters_deployment
+    fetch_kubeconfig_contexts
 }
 
 function deploy_submariner() {
@@ -59,7 +60,6 @@ function deploy_submariner() {
 
 function test_submariner() {
     verify_subctl_command
-    fetch_kubeconfig_contexts
     execute_submariner_tests
 }
 


### PR DESCRIPTION
The kubeconfig files of the managed clusters will be required by both
stages - deploy and test.
To be available widly, mode the function in to the "helper_functions".