### PR TITLE
Add downstream deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,20 @@ If one of the provided platforms does not exist, deployment and test will contin
 with the existing platforms, but after the tests execution, the flow will fail with  
 an error message that one of the requested platforms was not found.
 
+```bash
+./run.sh --deploy --downstream
+```
+
+Downstream flag will perform submariner deployment from brew.registry.redhat.io.  
+**Note** - Brew secret should exists for this deployment.
+
+```bash
+./run.sh --deploy --version 0.11.1
+```
+
+Specify the Submariner version that needs to be deployed.  
+Specified version will be verified against supported versions.
+
 ## Tests
 Submariner addon testing performed by using the `subctl` command.  
 The tools will be downloaded during the testing to the executors machine.

--- a/lib/acm_prepare_for_submariner.sh
+++ b/lib/acm_prepare_for_submariner.sh
@@ -31,3 +31,33 @@ function assign_clusters_to_clusterset() {
     fi
     INFO "Clusters have been assigned to the clusterset $CLUSTERSET. Assigned: $assigned_clusters"
 }
+
+function fetch_multiclusterhub_version() {
+    local mch_version
+
+    mch_version=$(oc get multiclusterhub -A -o jsonpath='{.items[0].status.currentVersion}')
+    echo "$mch_version"
+}
+
+# The submariner version selection will be done
+# when brew image source will be selected.
+# Otherwise, it will install from official source:
+# catalog.redhat.com
+function select_submariner_version_to_deploy() {
+    INFO "Select downstream Submariner version to deploy"
+    local mch_ver
+
+    mch_ver=$(fetch_multiclusterhub_version)
+    INFO "MultiClusterHub version - $mch_ver"
+
+    for key in ${!COMPONENT_VERSION[*]}; do
+        if [[ "$mch_ver" == "$key"* ]]; then
+            SUBMARINER_VERSION_INSTALL="${COMPONENT_VERSION[$key]}"
+            INFO "Submariner version - $SUBMARINER_VERSION_INSTALL will be installed"
+        fi
+    done
+
+    if [[ -z "$SUBMARINER_VERSION_INSTALL" ]]; then
+        ERROR "Unable to match between ACM and Submariner versions"
+    fi
+}

--- a/lib/helper_functions.sh
+++ b/lib/helper_functions.sh
@@ -44,18 +44,30 @@ function usage() {
     export OC_CLUSTER_PASS=<password of the cluster user>
 
     Arguments:
-    --all      - Perform deployment and testing of the Submariner addon
+    --all        - Perform deployment and testing of the Submariner addon
 
-    --deploy   - Perform deployment of the Submariner addon
+    --deploy     - Perform deployment of the Submariner addon
 
-    --test     - Perform testing of the Submariner addon
+    --test       - Perform testing of the Submariner addon
 
-    --platform - Specify the platforms that should be used for testing
-                 Separate multiple platforms by comma
-                 (Optional)
-                 By default - aws,gcp
+    --platform   - Specify the platforms that should be used for testing
+                   Separate multiple platforms by comma
+                   (Optional)
+                   By default - aws,gcp
 
-    --help|-h  - Print help
+    --version    - Specify Submariner version to be deployed
+                   (Optional)
+                   If not specified, submariner version will be chosen
+                   based of the ACM hub support
+
+    --downstream - Use the flag if downsteram images should be used.
+                   Submariner images could be sourced from two places:
+                     * Official Red Hat ragistry - registry.redhat.io
+                     * Downstream Quay registry - brew.registry.redhat.io
+                   (Optional)
+                   If flag is not used, official registry will be used
+
+    --help|-h    - Print help
 EOF
 }
 
@@ -78,4 +90,12 @@ function fetch_kubeconfig_contexts() {
             | .current-context = env(CL)
             | .users[].name = env(CL)' "$TESTS_LOGS/$cluster-kubeconfig.yaml"
     done
+}
+
+function validate_given_submariner_version() {
+    INFO "Validate given Submariner version with supported versions"
+    if [[ ! "${SUPPORTED_SUBMARINER_VERSIONS[*]}" =~ $SUBMARINER_VERSION_INSTALL ]]; then
+        ERROR "Suplied Submariner version is not supported. Supported versions - ${SUPPORTED_SUBMARINER_VERSIONS[*]}"
+    fi
+    INFO "Submariner version provided manually - $SUBMARINER_VERSION_INSTALL"
 }

--- a/resources/catalog-source.yaml
+++ b/resources/catalog-source.yaml
@@ -1,0 +1,13 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: submariner-catalog
+  namespace: openshift-marketplace
+spec:
+  sourceType: grpc
+  image: "$BREW_IIB_URL"
+  displayName: Testing Catalog Source
+  publisher: Red Hat Partner (Test)
+  updateStrategy:
+    registryPoll:
+      interval: 5m

--- a/resources/image-content-source-policy.yaml
+++ b/resources/image-content-source-policy.yaml
@@ -1,0 +1,15 @@
+apiVersion: operator.openshift.io/v1alpha1
+kind: ImageContentSourcePolicy
+metadata:
+  name: brew-registry
+spec:
+  repositoryDigestMirrors:
+  - mirrors:
+    - "$BREW_REGISTRY"
+    source: registry.redhat.io
+  - mirrors:
+    - "$BREW_REGISTRY"
+    source: registry.stage.redhat.io
+  - mirrors:
+    - "$BREW_REGISTRY"
+    source: registry-proxy.engineering.redhat.com

--- a/resources/submariner-config.yaml
+++ b/resources/submariner-config.yaml
@@ -2,10 +2,15 @@ apiVersion: submarineraddon.open-cluster-management.io/v1alpha1
 kind: SubmarinerConfig
 metadata:
   name: submariner
-  namespace: test-cluster
+  namespace: $managed_cluster_namespace
 spec:
   gatewayConfig:
     aws:
       instanceType: c5d.large
   credentialsSecret:
-    name: submariner
+    name: $managed_cluster_platform_secret
+  subscriptionConfig:
+    channel: $submariner_channel
+    source: submariner-catalog
+    sourceNamespace: openshift-marketplace
+    startingCSV: $submariner_version


### PR DESCRIPTION
- Add "--downstream" flag.
  When used, submariner images pulled from brew.registry.redhat.io
  Deployment of the submariner version will be done based on the support
  matrix of ACM.
  ACM 2.4 - Submariner 0.11.1
  ACM 2.5 - Submariner 0.12

  When "--downstream" flag is not used, official registry will be used:
  registry.redhat.io.

- Downstream prepare flow has been added.
  When downstream flag selected, specific preparation will be performed
  on each of the managed clusters.
  - An ImageContentSourcePolicy will be created to add brew mirror.
  - A CatalogSource will be added to specify the iib image to be used by
    the deployment to pull the submariner components images.
  - Based on the UBM query, iib (image index builde) image will be
    seleted to be used for the CatalogSource.

- Add "--version" flag.
  User will be able to manually specify submariner version deployment.
  That will override automatic version selection described above.
  The version specified manually will be verified against the supported
  submariner versions.

- Add "subscription" configration to SubmarinerConfig configuration
  object to specify the submariner version for deployment.

- README file has been updated.