### PR TITLE
Support multiple clusters test

### DIFF
--- a/lib/submariner_test.sh
+++ b/lib/submariner_test.sh
@@ -30,23 +30,62 @@ function execute_submariner_tests() {
 
         INFO "Show all Submariner information"
         subctl show all 2>&1 \
-            | tee  "$TESTS_LOGS/subctl_show_all_${primary_test_cluster}_${secondary_test_cluster}.log"
+            | tee  "$TESTS_LOGS/subctl_show_all_${primary_test_cluster}_${secondary_test_cluster}.log" \
+            || add_test_error $?
 
         INFO "Execute diagnose all tests"
         subctl diagnose all 2>&1 \
-            | tee "$TESTS_LOGS/subctl_diagnose_all_${primary_test_cluster}_${secondary_test_cluster}.log"
+            | tee "$TESTS_LOGS/subctl_diagnose_all_${primary_test_cluster}_${secondary_test_cluster}.log" \
+            || add_test_error $?
 
         INFO "Execute diagnose firewall inter-cluster tests"
         subctl diagnose firewall inter-cluster \
             "$TESTS_LOGS/$primary_test_cluster-kubeconfig.yaml" \
             "$TESTS_LOGS/$secondary_test_cluster-kubeconfig.yaml" 2>&1 \
-            |  tee "$TESTS_LOGS/subctl_firewall_tests_${primary_test_cluster}_${secondary_test_cluster}.log"
+            |  tee "$TESTS_LOGS/subctl_firewall_tests_${primary_test_cluster}_${secondary_test_cluster}.log" \
+            || add_test_error $?
 
         INFO "Execute E2E tests"
         subctl verify --only service-discovery,connectivity --verbose \
             --kubecontexts "$primary_test_cluster","$secondary_test_cluster" 2>&1 \
-            | tee "$TESTS_LOGS/subctl_e2e_tests_${primary_test_cluster}_${secondary_test_cluster}.log"
+            | tee "$TESTS_LOGS/subctl_e2e_tests_${primary_test_cluster}_${secondary_test_cluster}.log" \
+            || add_test_error $?
     done
-    INFO "All the tests finished successfully"
+    INFO "Tests execution finished"
     INFO "All the logs are placed within the $TESTS_LOGS directory"
+}
+
+# When one of the tests fails, add the error note to a global variable.
+# At the end of all tests, the variable will be checked.
+# If error occured, tests errors will be printed
+function add_test_error() {
+    local test_exit_code="$1"
+
+    if (( "$test_exit_code" > 0 )); then
+        WARNING "One of the tests failed... Adding to log"
+        export TESTS_FAILURES="true"
+    fi
+}
+
+function get_tests_failures() {
+    WARNING "The following tests failures occured"
+
+    local diagnose_logs
+    local e2e_tests_log
+
+    for log in "$TESTS_LOGS"/*.log; do
+        diagnose_logs=$(grep --no-messages '✗' "$log" || true)
+        if [[ -n "$diagnose_logs" ]]; then
+            echo
+            WARNING "Erros found in the following tests - $log"
+            echo "$diagnose_logs"
+        fi
+
+        e2e_tests_log=$(sed -n -e '/Summarizing.*.Failures/,$p' "$log")
+        if [[ -n "$e2e_tests_log" ]]; then
+            echo
+            WARNING "Erros found in the following tests - $log"
+            echo "$e2e_tests_log"
+        fi
+    done
 }

--- a/run.sh
+++ b/run.sh
@@ -16,6 +16,7 @@ export SUPPORTED_PLATFORMS="aws,gcp"  # Supported platform definition
 # The testing will be performed,
 # but the failure of the final result will be set.
 export FAILURES=""
+export TESTS_FAILURES="false"
 
 # Submariner versioning and image sourcing
 
@@ -24,7 +25,7 @@ export FAILURES=""
 # The value will define the version of Submariner
 declare -A COMPONENT_VERSION
 export COMPONENT_VERSION
-COMPONENT_VERSION["2.4"]="0.11.1"
+COMPONENT_VERSION["2.4"]="0.11.2"
 COMPONENT_VERSION["2.5"]="0.12.0"
 # Submariner images could be taken from two different places:
 # * Official Red Hat registry - registry.redhat.io
@@ -36,7 +37,7 @@ export DOWNSTREAM="false"
 # if the source of the images will be set to quay (downstream).
 # The submariner version will be selected automatically.
 export SUBMARINER_VERSION_INSTALL=""
-export SUPPORTED_SUBMARINER_VERSIONS=("0.11.0" "0.11.1" "0.12.0")
+export SUPPORTED_SUBMARINER_VERSIONS=("0.11.0" "0.11.2" "0.12.0")
 
 export BREW_REGISTRY="brew.registry.redhat.io"
 export LATEST_IIB=""
@@ -102,8 +103,13 @@ function test_submariner() {
 }
 
 function finalize() {
-    if  [[ -n "$FAILURES" ]]; then
-        ERROR "Execution finished, but the following failures detected: $FAILURES"
+    if [[ "$TESTS_FAILURES" == "true" ]]; then
+        WARNING "Tests execution contains failures"
+        get_tests_failures
+    fi
+
+    if [[ -n "$FAILURES" ]]; then
+        WARNING "Execution finished, but the following failures detected: $FAILURES"
     fi
 }
 


### PR DESCRIPTION
Add the ability to test multiple managed clusters with submariner
component installed.
The test flow will test all available submariner clusters and in case
tests failures were present, will print them at the end.