### PR TITLE
Check for clusters availability

### DIFF
--- a/lib/validate_acm_readiness.sh
+++ b/lib/validate_acm_readiness.sh
@@ -48,13 +48,13 @@ function check_clusters_deployment() {
 
     MANAGED_CLUSTERS=$(oc get clusterdeployment -A \
                          --selector "hive.openshift.io/cluster-platform in ($PLATFORM)" \
-                         --no-headers=true -o custom-columns=NAME:.metadata.name)
+                         -o jsonpath='{range.items[?(@.status.powerState=="Running")]}{.metadata.name}{"\n"}{end}')
     clusters_count=$(echo "$MANAGED_CLUSTERS" | wc -w)
 
     if [[ "$clusters_count" -lt 2 ]]; then
         ERROR "At least two managed clusters required for Submariner deployment. Found - $clusters_count"
     fi
 
-    INFO "Found the following managed clusters:"
+    INFO "Found the following active managed clusters:"
     INFO "$MANAGED_CLUSTERS"
 }


### PR DESCRIPTION
Managed clusters could be in a different state:
- Running
- Hibernated

In case the cluster not currently active and running, it should be
skipped from the execution of the pipeline.
Add check for the running state of the managed clusters.