### PR TITLE
Add broker resource

### DIFF
--- a/lib/downstream_prepare.sh
+++ b/lib/downstream_prepare.sh
@@ -108,7 +108,7 @@ function verify_package_manifest() {
 
     local manifest_ver
     local submariner_version="$SUBMARINER_VERSION_INSTALL"
-    local wait_timeout=6
+    local wait_timeout=30
     local timeout=0
     local catalog_ns="openshift-marketplace"
 

--- a/lib/helper_functions.sh
+++ b/lib/helper_functions.sh
@@ -60,6 +60,12 @@ function usage() {
                    If not specified, submariner version will be chosen
                    based of the ACM hub support
 
+    --globalnet  - Set the state of the Globalnet for the Submariner deployment.
+                   The globalnet configuration will be applied starting from
+                   ACM version 2.5.0 and Submariner 0.12.0
+                   (Optional)
+                   By default - false
+
     --downstream - Use the flag if downsteram images should be used.
                    Submariner images could be sourced from two places:
                      * Official Red Hat ragistry - registry.redhat.io
@@ -167,4 +173,26 @@ function raw_to_url_encode() {
         encoded+="${o}"
     done
     echo "${encoded}"
+}
+
+# Validate versions
+# The function will get two versions:
+# First - Base varsion
+# Second - Current version
+# The function will return the state of the current
+# version comparing to the base:
+# If current version equal or highter than base - "valid"
+# If current version lower than base - "not_valid"
+function validate_version() {
+    local base_version="$1"
+    local current_version="$2"
+    local version_state="not_valid"
+
+    if test "$(echo "$base_version $current_version" | tr " " "\n" | sort -rV | head -n 1)" == "$current_version"; then
+        version_state="valid"
+    fi
+    if test "$(echo "$base_version $current_version" | tr " " "\n" | sort -rV | head -n 1)" != "$current_version"; then
+        version_state="not_valid"
+    fi
+    echo "$version_state"
 }

--- a/lib/submariner_deploy.sh
+++ b/lib/submariner_deploy.sh
@@ -48,6 +48,26 @@ function prepare_clusters_for_submariner() {
     done
 }
 
+# Starting ACM 2.5.0 and Submariner version 0.12.0
+# a new object has been introdused - Broker.
+function deploy_submariner_broker() {
+    local subm_broker_ver="0.12.0"
+    local version_state
+    version_state=$(validate_version "$subm_broker_ver" "$SUBMARINER_VERSION_INSTALL")
+
+    if [[ "$version_state" == "not_valid" ]]; then
+        INFO "The ACM version if lower that 2.5.0. Broker resource will not be created"
+    elif [[ "$version_state" == "valid" ]]; then
+        INFO "Deploy Submariner broker"
+        INFO "The Globalnet conditiona has been set to - $SUBMARINER_GLOBALNET"
+        local broker_ns="$CLUSTERSET-broker"
+
+        NS="$broker_ns" yq eval '.metadata.namespace = env(NS)
+            | .spec.globalnetEnabled = env(SUBMARINER_GLOBALNET)' \
+            "$SCRIPT_DIR/resources/broker.yaml" | oc apply -f -
+    fi
+}
+
 function deploy_submariner_addon() {
     INFO "Perform deployment of Submariner addon"
 

--- a/resources/broker.yaml
+++ b/resources/broker.yaml
@@ -1,0 +1,7 @@
+apiVersion: submariner.io/v1alpha1
+kind: Broker
+metadata:
+  name: submariner-broker
+  namespace: submariner-broker
+spec:
+  globalnetEnabled: true

--- a/run.sh
+++ b/run.sh
@@ -7,6 +7,7 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
 
 export CLUSTERSET="submariner"
 export SUBMARINER_NS="submariner-operator"
+export SUBMARINER_GLOBALNET="false"
 export MANAGED_CLUSTERS=""
 export TESTS_LOGS="$SCRIPT_DIR/tests_logs"
 export SUBCTL_URL_DOWNLOAD="https://github.com/submariner-io/releases/releases"
@@ -125,8 +126,11 @@ function deploy_submariner() {
             import_images_into_local_registry
         fi
 
-        # Disabled due to https://issues.redhat.com/browse/RFE-1608
-        # create_icsp
+        if [[ "$LOCAL_MIRROR" == 'false' ]]; then
+            # https://issues.redhat.com/browse/RFE-1608
+            create_icsp
+        fi
+
         create_catalog_source
         verify_package_manifest
     fi
@@ -134,6 +138,7 @@ function deploy_submariner() {
     create_clusterset
     assign_clusters_to_clusterset
     prepare_clusters_for_submariner
+    deploy_submariner_broker
     deploy_submariner_addon
     wait_for_submariner_ready_state
 }
@@ -178,6 +183,12 @@ function parse_arguments() {
             --version)
                 if [[ -n "$2" ]]; then
                     SUBMARINER_VERSION_INSTALL="$2"
+                    shift 2
+                fi
+                ;;
+            --globalnet)
+                if [[ -n "$2" ]]; then
+                    SUBMARINER_GLOBALNET="$2"
                     shift 2
                 fi
                 ;;


### PR DESCRIPTION
Starting from ACM 2.5.0 and Submariner 0.12.0, Globalnet support has
been added to the Submariner as part of the HUB.

- Add broker resource deployment
- Add version check to deploy broker starting from submainer 0.12.0
- Add globalnet script parameter