### PR TITLE
Fix CatalogSource creation

### DIFF
--- a/lib/downstream_prepare.sh
+++ b/lib/downstream_prepare.sh
@@ -61,6 +61,7 @@ function create_catalog_source() {
         INFO "Detected IIB - $LATEST_IIB"
     else
         get_latest_iib
+        image_source="$LATEST_IIB"
     fi
 
     local catalog_ns="openshift-marketplace"


### PR DESCRIPTION
The CatalogSource object has two ways of creation:
1) IIB is defined directly from Brew.
2) IIB is defined from the internal ocp registry.

Fix the Brew IIB reference.