### PR TITLE
Add 'trap' check

### DIFF
--- a/lib/helper_functions.sh
+++ b/lib/helper_functions.sh
@@ -25,6 +25,7 @@ function WARNING() {
 function ERROR() {
     local message="$1"
     echo -e "${RED}ERROR: ${NO_COLOR}${message}"
+    FAILURES+="${RED}ERROR: ${NO_COLOR}${message}"
     exit 1
 }
 
@@ -195,4 +196,13 @@ function validate_version() {
         version_state="not_valid"
     fi
     echo "$version_state"
+}
+
+function catch_error() {
+    if [[ "$1" != "0" ]]; then
+        gather_debug_info
+        if [[ -n "$FAILURES" ]]; then
+            echo -e "\nExecution aborted. The following failures detected:\n$FAILURES"
+        fi
+    fi
 }

--- a/run.sh
+++ b/run.sh
@@ -2,6 +2,8 @@
 
 set -eo pipefail
 
+trap 'catch_error $?' EXIT
+
 # Global variables
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
 


### PR DESCRIPTION
The added 'trap' check in case of the execution failure will call the
gather_debug_info function and collect environment information.
After that the execution will be aborted with the error message that
caused the failure.