### PR TITLE
Add support for claim clusters

### DIFF
--- a/lib/helper_functions.sh
+++ b/lib/helper_functions.sh
@@ -18,13 +18,13 @@ function INFO() {
 # Print the message with a prefix WARNING with YELLOW color
 function WARNING() {
     local message="$1"
-    echo -e "${YELLOW}WARNING: ${NO_COLOR}${message}"
+    echo -e "\n${YELLOW}WARNING: ${NO_COLOR}${message}\n"
 }
 
 # Print the message with a prefix ERROR with RED color and fail the execution
 function ERROR() {
     local message="$1"
-    echo -e "${RED}ERROR: ${NO_COLOR}${message}"
+    echo -e "\n${RED}ERROR: ${NO_COLOR}${message}"
     FAILURES+="${RED}ERROR: ${NO_COLOR}${message}"
     exit 1
 }
@@ -223,9 +223,11 @@ function validate_version() {
 
 function catch_error() {
     if [[ "$1" != "0" ]]; then
-        gather_debug_info
-        if [[ -n "$FAILURES" ]]; then
-            echo -e "\nExecution aborted. The following failures detected:\n$FAILURES"
+        if [[ "$GATHER_LOGS" == "true" ]]; then
+            gather_debug_info
+            if [[ -n "$FAILURES" ]]; then
+                echo -e "\nExecution aborted. The following failures detected:\n$FAILURES"
+            fi
         fi
     fi
 }

--- a/lib/prerequisites.sh
+++ b/lib/prerequisites.sh
@@ -16,9 +16,9 @@ function verify_ocp_clients() {
         
         # Add local BIN dir to PATH
         [[ ":$PATH:" = *":$HOME/.local/bin:"* ]] || export PATH="$HOME/.local/bin:$PATH"
-        INFO "The oc and kubectl installed."
+        INFO "The oc and kubectl installed"
     fi
-    INFO "The oc and kubectl commands found."
+    INFO "The oc and kubectl commands found"
 }
 
 function verify_yq() {
@@ -34,9 +34,9 @@ function verify_yq() {
             # Add local BIN dir to PATH
             [[ ":$PATH:" = *":$HOME/.local/bin:"* ]] || export PATH="$HOME/.local/bin:$PATH"
         fi
-        INFO "The yq command installed."
+        INFO "The yq command installed"
     fi
-    INFO "The yq command is found."
+    INFO "The yq command is found"
 }
 
 function verify_jq() {
@@ -48,7 +48,7 @@ function verify_jq() {
 
         # Add local BIN dir to PATH
         [[ ":$PATH:" = *":$HOME/.local/bin:"* ]] || export PATH="$HOME/.local/bin:$PATH"
-        INFO "The jq command installed."
+        INFO "The jq command installed"
     fi
     INFO "The jq command is found"
 }
@@ -67,7 +67,7 @@ function fetch_submariner_addon_version() {
     local sub_version
 
     sub_cluster_ns=$(oc get clusterdeployment -A \
-                   --selector=cluster.open-cluster-management.io/clusterset=submariner \
+                   --selector=cluster.open-cluster-management.io/clusterset="$CLUSTERSET" \
                    -o jsonpath='{.items[0].metadata.namespace}')
     sub_version=$(oc get managedclusteraddon/submariner -n "$sub_cluster_ns" \
                     -o jsonpath='{.status.conditions[?(@.type == "SubmarinerAgentDegraded")].message}' \

--- a/resources/namespace.yaml
+++ b/resources/namespace.yaml
@@ -2,3 +2,4 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: "$TEST_NAMESPACE"
+  annotations: {}

--- a/run.sh
+++ b/run.sh
@@ -110,6 +110,7 @@ function prepare() {
     login_to_cluster "hub"
 
     check_clusters_deployment
+    check_for_claim_cluster_with_pre_set_clusterset
     fetch_kubeconfig_contexts_and_pass
 }
 


### PR DESCRIPTION
When a cluster claimed from a pool and has a pre-set clusterset, that
clusterset should be used as a clusterset for submariner deployment.
This is due to limitation of the acm - claim cluster could not be
removed from pre-set clusterset.