### PR TITLE
Set 0.12.0 to use stable channel and omit "tech-preview"

### DIFF
--- a/lib/acm_prepare_for_submariner.sh
+++ b/lib/acm_prepare_for_submariner.sh
@@ -43,21 +43,25 @@ function fetch_multiclusterhub_version() {
 # when brew image source will be selected.
 # Otherwise, it will install from official source:
 # catalog.redhat.com
-function select_submariner_version_to_deploy() {
-    INFO "Select downstream Submariner version to deploy"
+function select_submariner_version_and_channel_to_deploy() {
+    INFO "Select Submariner version and channel to deploy"
     local mch_ver
 
     mch_ver=$(fetch_multiclusterhub_version)
     INFO "MultiClusterHub version - $mch_ver"
 
-    for key in ${!COMPONENT_VERSION[*]}; do
-        if [[ "$mch_ver" == "$key"* ]]; then
-            SUBMARINER_VERSION_INSTALL="${COMPONENT_VERSION[$key]}"
-            INFO "Submariner version - $SUBMARINER_VERSION_INSTALL will be installed"
+    # Declare loop variable as acm_ref
+    declare -n acm_ref
+    for acm_ref in "${COMPONENT_VERSIONS[@]}"; do
+        if [[ "$mch_ver" == "${acm_ref[acm_version]}"* ]]; then
+            SUBMARINER_VERSION_INSTALL="${acm_ref[submariner_version]}"
+            SUBMARINER_CHANNEL_RELEASE="${acm_ref[channel]}"
+            INFO "Submariner version - $SUBMARINER_VERSION_INSTALL will be installed
+            into the '$SUBMARINER_CHANNEL_RELEASE' channel"
         fi
     done
 
-    if [[ -z "$SUBMARINER_VERSION_INSTALL" ]]; then
-        ERROR "Unable to match between ACM and Submariner versions"
+    if [[ -z "$SUBMARINER_VERSION_INSTALL" || -z "$SUBMARINER_CHANNEL_RELEASE" ]]; then
+        ERROR "Unable to match between ACM and Submariner/channel versions"
     fi
 }

--- a/lib/submariner_deploy.sh
+++ b/lib/submariner_deploy.sh
@@ -29,7 +29,7 @@ function prepare_clusters_for_submariner() {
         catalog_ns="$SUBMARINER_NS"
     fi
 
-    submariner_channel="alpha-$(echo "$SUBMARINER_VERSION_INSTALL" | grep -Po '.*(?=\.)')"
+    submariner_channel="$SUBMARINER_CHANNEL_RELEASE-$(echo "$SUBMARINER_VERSION_INSTALL" | grep -Po '.*(?=\.)')"
     submariner_version="submariner.v$SUBMARINER_VERSION_INSTALL"
 
     for cluster in $MANAGED_CLUSTERS; do

--- a/run.sh
+++ b/run.sh
@@ -27,14 +27,27 @@ export FAILURES=""
 export TESTS_FAILURES="false"
 
 # Submariner versioning and image sourcing
-
-# Declare a map to define submariner versions to ACM versions
+# Declare a map to define submariner versions and channel to ACM versions
 # The key will define the version of ACM
-# The value will define the version of Submariner
-declare -A COMPONENT_VERSION
-export COMPONENT_VERSION
-COMPONENT_VERSION["2.4"]="0.11.2"
-COMPONENT_VERSION["2.5"]="0.12.0"
+# The value will define the version of Submariner and a channel
+
+# Declare associative arrays
+declare -A ACM_2_4=(
+    [acm_version]='2.4'
+    [submariner_version]='0.11.2'
+    [channel]='alpha'
+)
+export ACM_2_4
+declare -A ACM_2_5=(
+    [acm_version]='2.5'
+    [submariner_version]='0.12.0'
+    [channel]='stable'
+)
+export ACM_2_5
+# Declare array of COMPONENTS_VERSIONS of associative arrays
+export COMPONENT_VERSIONS=("${!ACM@}")
+
+
 # Submariner images could be taken from two different places:
 # * Official Red Hat registry - registry.redhat.io
 # * Downstream Brew registry - brew.registry.redhat.io
@@ -49,6 +62,7 @@ export LOCAL_MIRROR="true"
 # The submariner version will be selected automatically.
 export SUBMARINER_VERSION_INSTALL=""
 export SUPPORTED_SUBMARINER_VERSIONS=("0.11.0" "0.11.2" "0.12.0")
+export SUBMARINER_CHANNEL_RELEASE=""
 # Official RedHat registry
 export OFFICIAL_REGISTRY="registry.redhat.io"
 export STAGING_REGISTRY="registry.stage.redhat.io"
@@ -118,7 +132,7 @@ function deploy_submariner() {
     if [[ -n "$SUBMARINER_VERSION_INSTALL" ]]; then
         validate_given_submariner_version
     else
-        select_submariner_version_to_deploy
+        select_submariner_version_and_channel_to_deploy
     fi
 
     if [[ "$DOWNSTREAM" == 'true' ]]; then


### PR DESCRIPTION
- As ACM 2.5 and Submariner 0.12.0 is going GA, the channel that should be
  used for submariner deployment should be "stable" instead of "alpha".
- Remove "tech-preview" suffix from the repository path.