### PR TITLE
Add JUnit report to tests execution

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,6 +77,7 @@ pipeline {
     post {
         always {
             archiveArtifacts artifacts: "logs/**/*.*", followSymlinks: false
+            junit allowEmptyResults: true, testResults: "logs/*.xml"
         }
     }
 }

--- a/lib/prerequisites.sh
+++ b/lib/prerequisites.sh
@@ -80,19 +80,26 @@ function get_subctl_for_testing() {
 
     local subctl_version
     local subctl_download_url
+    local subctl_bin
     subctl_version=$(fetch_submariner_addon_version)
-    subctl_download_url="$SUBCTL_URL_DOWNLOAD/download/$subctl_version/subctl-$subctl_version-linux-amd64.tar.xz"
+
+    if [[ "$subctl_version" == "v0.11"*  ]]; then
+        subctl_download_url="$SUBCTL_URL_DOWNLOAD/download/$subctl_version/subctl-$subctl_version-linux-amd64.tar.xz"
+    else
+        WARNING "Due to https://github.com/submariner-io/submariner-operator/issues/1977 devel version will be used"
+        subctl_download_url="$SUBM_OPERATOR_URL/releases/download/subctl-devel/subctl-devel-linux-amd64.tar.xz"
+    fi
 
     INFO "Submariner addon version - $subctl_version"
     INFO "Download subctl from - $subctl_download_url"
 
-    wget -qO- "$subctl_download_url" -O "subctl-$subctl_version-linux-amd64.tar.xz"
-    tar xfJ "subctl-$subctl_version-linux-amd64.tar.xz"
+    wget -qO- "$subctl_download_url" -O subctl.tar.xz
+    tar xfJ subctl.tar.xz --strip-components 1
+    subctl_bin=$(find . -maxdepth 1 -name "subctl*linux-amd64")
 
     mkdir -p "$HOME"/.local/bin
-    cp "subctl-$subctl_version/subctl-$subctl_version-linux-amd64" "$HOME"/.local/bin/subctl
-
-    rm -rf "subctl-$subctl_version-linux-amd64.tar.xz" "subctl-$subctl_version"
+    cp "$subctl_bin" "$HOME"/.local/bin/subctl
+    rm -rf "$subctl_bin" subctl.tar.xz
 
     # Add local BIN dir to PATH
     [[ ":$PATH:" = *":$HOME/.local/bin:"* ]] || export PATH="$HOME/.local/bin:$PATH"

--- a/lib/submariner_test.sh
+++ b/lib/submariner_test.sh
@@ -15,6 +15,10 @@ function execute_submariner_tests() {
     rm -rf "$TESTS_LOGS"
     mkdir -p "$TESTS_LOGS"
 
+    # Due to https://github.com/submariner-io/submariner-operator/issues/1977
+    local subctl_extra_args="--verbose --junit-report $TESTS_LOGS/submariner_e2e.xml"
+    subctl verify --help | grep -q --no-messages junit-report || subctl_extra_args="--verbose"
+
     # Subctl E2E tests are working with 2 clusters only at a time
     local primary_test_cluster
     local secondary_test_cluster
@@ -49,7 +53,7 @@ function execute_submariner_tests() {
             || add_test_error $?
 
         INFO "Execute E2E tests"
-        subctl verify --only service-discovery,connectivity --verbose \
+        subctl verify --only service-discovery,connectivity "$subctl_extra_args" \
             --kubecontexts "$primary_test_cluster","$secondary_test_cluster" 2>&1 \
             | tee "$TESTS_LOGS/subctl_e2e_tests_${primary_test_cluster}_${secondary_test_cluster}.log" \
             || add_test_error $?

--- a/run.sh
+++ b/run.sh
@@ -17,6 +17,7 @@ export TESTS_LOGS="$LOGS/tests_logs"
 export DEBUG_LOGS="$LOGS/debug_logs"
 export LOG_PATH=""
 export SUBCTL_URL_DOWNLOAD="https://github.com/submariner-io/releases/releases"
+export SUBM_OPERATOR_URL="https://github.com/submariner-io/submariner-operator"
 export PLATFORM="aws,gcp"  # Default platform definition
 export SUPPORTED_PLATFORMS="aws,gcp"  # Supported platform definition
 # Non critial failures will be stored into the variable


### PR DESCRIPTION
Starting from 2.5/0.12.0, subctl will generate a junit report by
using the "--junit-report" flag.
In version 0.12.2, the equivalent version of subctl will be used and
that version does not contain the required flag.

Currently, "devel" version of "subctl" will be used, until the falg will
be backported into the release-0.12.
https://github.com/submariner-io/submariner-operator/issues/1977