### PR TITLE
Fix "subctl verify" command execution

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,7 +77,7 @@ pipeline {
     post {
         always {
             archiveArtifacts artifacts: "logs/**/*.*", followSymlinks: false
-            junit allowEmptyResults: true, testResults: "logs/*.xml"
+            junit allowEmptyResults: true, testResults: "logs/**/*.xml"
         }
     }
 }


### PR DESCRIPTION
The "subctl verify" test command execution has a difference between the
submariner 0.11.2 and 0.12.0.
In the newer versions, the "--junit-report" flag has been added.
Due to the "subctl" command issue with combaining arguments in bash, the
execution command are doubled :(...