### PR TITLE
Add conditional check for PackageManifest

### DIFF
--- a/lib/downstream_prepare.sh
+++ b/lib/downstream_prepare.sh
@@ -130,7 +130,7 @@ function verify_package_manifest() {
                             oc -n "$catalog_ns" get packagemanifest submariner \
                             -o jsonpath='{.status.channels[?(@.currentCSV == "'"submariner.v$submariner_version"'")].currentCSVDesc.version}')
 
-            if [[ -n "$manifest_ver" ]]; then
+            if [[ -n "$manifest_ver" && "$manifest_ver" == "$submariner_version" ]]; then
                 continue 2
             fi
             sleep $(( timeout++ ))


### PR DESCRIPTION
The PackageManifest may return an error if the specific manifest was yet
created.
Add a condition to check for the expected output.