### PR TITLE
Fix GLOBALNET parameter in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,7 +34,7 @@ pipeline {
             steps {
                 script {
                     GLOBALNET = ""
-                    if (params.GLOBALNET != '') {
+                    if (params.GLOBALNET) {
                         GLOBALNET = "--globalnet true"
                     }
 


### PR DESCRIPTION
The condition of the "GLOBALNET" should check the boolean and not
string.