### PR TITLE
Name E2E results file with cluster names

### DIFF
--- a/lib/submariner_test.sh
+++ b/lib/submariner_test.sh
@@ -52,7 +52,7 @@ function execute_submariner_tests() {
         # Due to https://github.com/submariner-io/submariner-operator/issues/1977
         if subctl verify --help | grep -q --no-messages junit-report; then
             subctl verify --only service-discovery,connectivity --verbose \
-                --junit-report "$TESTS_LOGS/submariner_e2e.xml" \
+                --junit-report "$TESTS_LOGS/submariner_e2e_${primary_test_cluster}_${secondary_test_cluster}.xml" \
                 --kubecontexts "$primary_test_cluster,$secondary_test_cluster" 2>&1 \
                 | tee "$TESTS_LOGS/subctl_e2e_tests_${primary_test_cluster}_${secondary_test_cluster}.log" \
                 || add_test_error $?


### PR DESCRIPTION
The test flow could include multiple managed clusters.
When e2e test is running, we need to be able to identify the results
file with the clusters that it was executed on.
Set the name of the junit file with the following name staructure:

"submariner_e2e_<first_cluster_name>_<second_cluster_name>.xml