### PR TITLE
Add control of Globalnet parameter to Jenkinsfile

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -132,10 +132,16 @@ function verify_required_env_vars() {
 # The job will be skipped.
 function validate_prerequisites() {
     INFO "Validate prerequisites for deployment"
+    local mch_ver
+
     verify_required_env_vars
     verify_prerequisites_tools
     login_to_cluster "hub"
     check_clusters_deployment
+
+    mch_ver=$(fetch_multiclusterhub_version)
+    echo "MultiClusterHub version:"
+    echo "$mch_ver" | tee mch_version.log
 
     if [[ -z "$VALIDATION_STATE" ]]; then
         VALIDATION_STATE+="The environment is ready for the test"


### PR DESCRIPTION
When the MultiClusterHub version is below 2.5.0, globalnet is not
supported.
Thus, disable it when a lower version of 2.5.0 is used.
In equal or higher version, parameter will be controlled by the user.
By default, globalnet will be used.