### PR TITLE
Prevent failure of the package manifest query

### DIFF
--- a/lib/downstream_prepare.sh
+++ b/lib/downstream_prepare.sh
@@ -141,7 +141,7 @@ function verify_package_manifest() {
         until [[ "$timeout" -eq "$wait_timeout" ]]; do
             INFO "Searching for Submariner version - $submariner_version in PackageManifest"
             manifest_ver=$(KUBECONFIG="$LOGS/$cluster-kubeconfig.yaml" \
-                            oc -n "$catalog_ns" get packagemanifest submariner \
+                            oc -n "$catalog_ns" get packagemanifest submariner --ignore-not-found \
                             -o jsonpath='{.status.channels[?(@.currentCSV == "'"submariner.v$submariner_version"'")].currentCSVDesc.version}')
 
             if [[ -n "$manifest_ver" && "$manifest_ver" == "$submariner_version" ]]; then


### PR DESCRIPTION
Creationg of the package manifest could take a few seconds.
In that case a query could fail with the api error of "package not
found".
Add the "--ingore-not-found" flag because the error check is done in the
next lines.