### PR TITLE
Set build job to "NOT_BUILT" when job skipped

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,6 +56,7 @@ pipeline {
                     // The job will not be executed.
                     if (state.contains('Not ready!')) {
                         EXECUTE_JOB = false
+                        currentBuild.result = 'NOT_BUILT'
                     } else {
                         EXECUTE_JOB = true
                     }


### PR DESCRIPTION
When the job environment prerequisites are not ready, the job skipped.
Set the build state of the job to "NOT_BUILT" to identify such jobs.

Signed-off-by: Maxim Babushkin <mbabushk@redhat.com>