### PR TITLE
Change the GLOBALNET default

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -9,7 +9,7 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
 
 export CLUSTERSET="submariner"
 export SUBMARINER_NS="submariner-operator"
-export SUBMARINER_GLOBALNET="false"
+export SUBMARINER_GLOBALNET="true"
 export MANAGED_CLUSTERS=""
 export GATHER_LOGS="true"
 export LOGS="$SCRIPT_DIR/logs"


### PR DESCRIPTION
As of ACM 2.5.0 / Submariner 0.12.0, globalnet is supported.
Changing the default deployment of globalnet to true.