### PR TITLE
Fix pods logs gathering

### DIFF
--- a/lib/gather_info.sh
+++ b/lib/gather_info.sh
@@ -136,7 +136,8 @@ function get_submariner_pods_logs() {
              get pods -o jsonpath='{.items[*].metadata.name}')
     for pod in $pods; do
         KUBECONFIG="$kube_conf" oc -n "$SUBMARINER_NS" \
-            logs "$pod" >> "$cluster_log"
+            logs "$pod" >> "$cluster_log" \
+            || echo "No logs found for pod $pod" >> "$cluster_log"
     done
 }
 


### PR DESCRIPTION
While pods logs gathering, could be a state where a pod have not started
and no logs to provide.
In that case print a "No logs found for pod" into the log file,
otherwise it will fail.