### PR TITLE
Refactor internal registry flow

### DIFF
--- a/lib/downstream_prepare.sh
+++ b/lib/downstream_prepare.sh
@@ -68,21 +68,13 @@ function get_latest_iib() {
 # and used to fetch the submariner components images
 function create_catalog_source() {
     INFO "Create CatalogSource on the managed clusters"
-    local ocp_registry_url
-    local ocp_registry_path
     local image_source="$LATEST_IIB"
+    local catalog_ns="openshift-marketplace"
 
     for cluster in $MANAGED_CLUSTERS; do
         get_latest_iib
         image_source="$LATEST_IIB"
 
-        local catalog_ns="openshift-marketplace"
-        if [[ "$DOWNSTREAM" == "true" && "$LOCAL_MIRROR" == "true" ]]; then
-            catalog_ns="$SUBMARINER_NS"
-            ocp_registry_url=$(oc registry info --internal)
-            ocp_registry_path="$ocp_registry_url/$SUBMARINER_NS/$SUBM_IMG_BUNDLE-index:v$SUBMARINER_VERSION_INSTALL"
-            image_source="$ocp_registry_path"
-        fi
 
         INFO "Create CatalogSource on $cluster cluster"
         IMG_SRC="$image_source" NS="$catalog_ns" \
@@ -124,10 +116,6 @@ function verify_package_manifest() {
     local wait_timeout=30
     local timeout
     local catalog_ns="openshift-marketplace"
-
-    if [[ "$DOWNSTREAM" == "true" && "$LOCAL_MIRROR" == "true" ]]; then
-        catalog_ns="$SUBMARINER_NS"
-    fi
 
     for cluster in $MANAGED_CLUSTERS; do
         INFO "Verify package manifest for cluster $cluster"
@@ -178,9 +166,6 @@ function create_brew_secret() {
     brew_sec=$(verify_brew_secret_existence)
 
     local secret_ns=("openshift-config" "openshift-marketplace")
-    if [[ "$DOWNSTREAM" == "true" && "$LOCAL_MIRROR" == "true" ]]; then
-        secret_ns+=("$SUBMARINER_NS")
-    fi
 
     for cluster in $MANAGED_CLUSTERS; do
         INFO "Create Brew secret on $cluster cluster"

--- a/lib/helper_functions.sh
+++ b/lib/helper_functions.sh
@@ -166,20 +166,6 @@ function login_to_cluster() {
     fi
 }
 
-# The function will return token of the given cluster name
-# The token information will be received based on the
-# available kubeconfig file within the "$LOGS" dir.
-function get_cluster_token() {
-    local cluster="$1"
-    local token="$2"
-
-    login_to_cluster "$cluster"
-    token=$(oc whoami -t)
-    echo "$token"
-
-    login_to_cluster "hub" &> /dev/null
-}
-
 # Fetch the name of the cloud credentials for the cluster
 function get_cluster_credential_name() {
     local cluster

--- a/lib/submariner_deploy.sh
+++ b/lib/submariner_deploy.sh
@@ -11,10 +11,6 @@ function prepare_clusters_for_submariner() {
     local submariner_version
     local catalog_ns="openshift-marketplace"
 
-    if [[ "$DOWNSTREAM" == "true" && "$LOCAL_MIRROR" == "true" ]]; then
-        catalog_ns="$SUBMARINER_NS"
-    fi
-
     submariner_channel="$SUBMARINER_CHANNEL_RELEASE-$(echo "$SUBMARINER_VERSION_INSTALL" | grep -Po '.*(?=\.)')"
     submariner_version="submariner.v$SUBMARINER_VERSION_INSTALL"
 

--- a/resources/image-stream.yaml
+++ b/resources/image-stream.yaml
@@ -1,0 +1,18 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: "$IMAGE_NAME"
+  namespace: openshift
+spec:
+  lookupPolicy:
+    local: false
+  tags:
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: "$SOURCE_IMAGE:$IMAGE_TAG"
+    generation: 1
+    importPolicy: {}
+    name: "$IMAGE_TAG"
+    referencePolicy:
+      type: Source

--- a/resources/service-account-role-config.yaml
+++ b/resources/service-account-role-config.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: "$ROLE_BINDING_NAME"
+  namespace: "$NAMESPACE"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:image-builder
+subjects:
+- kind: ServiceAccount
+  name: "$SERVICE_ACCOUNT_NAME"
+  namespace: "$NAMESPACE"
+

--- a/resources/service-account.yaml
+++ b/resources/service-account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "$SERVICE_ACCOUNT_NAME"
+  namespace: "$NAMESPACE"


### PR DESCRIPTION
- Change the authentication method for internal ocp registry.
  It was used an kubeadmin login token.
  The change creates a service account and uses it's secret for registry
  authentication.
- Place the imported images into the "openshift" namespace.
  This namespace is visible to all other namespaces.
- Place the CatalogSource for submariner in openshift-marketplace
  namespace. This is the common place for the CatalogSource objects.
- Change the import image raw command to use the ImageStream manifest.

Signed-off-by: Maxim Babushkin <mbabushk@redhat.com>