### PR TITLE
Update the subctl download binary url

### DIFF
--- a/lib/prerequisites.sh
+++ b/lib/prerequisites.sh
@@ -105,7 +105,7 @@ function get_subctl_for_testing() {
         subctl_download_url="$SUBCTL_URL_DOWNLOAD/download/$subctl_version/subctl-$subctl_version-linux-amd64.tar.xz"
     else
         WARNING "Due to https://github.com/submariner-io/submariner-operator/issues/1977 devel version will be used"
-        subctl_download_url="$SUBM_OPERATOR_URL/releases/download/subctl-devel/subctl-devel-linux-amd64.tar.xz"
+        subctl_download_url="$SUBCTL_UPSTREAM_URL/releases/download/subctl-devel/subctl-devel-linux-amd64.tar.xz"
     fi
 
     INFO "Submariner addon version - $subctl_version"

--- a/run.sh
+++ b/run.sh
@@ -17,7 +17,7 @@ export TESTS_LOGS="$LOGS/tests_logs"
 export DEBUG_LOGS="$LOGS/debug_logs"
 export LOG_PATH=""
 export SUBCTL_URL_DOWNLOAD="https://github.com/submariner-io/releases/releases"
-export SUBM_OPERATOR_URL="https://github.com/submariner-io/submariner-operator"
+export SUBCTL_UPSTREAM_URL="https://github.com/submariner-io/subctl"
 export PLATFORM="aws,gcp"  # Default platform definition
 export SUPPORTED_PLATFORMS="aws,gcp,azure"  # Supported platform definition
 # Non critial failures will be stored into the variable


### PR DESCRIPTION
The subctl binary changed from
https://github.com/submariner-io/submariner-operator to
https://github.com/submariner-io/subctl.

Update the sources to fetch the binary from the new path.