### PR TITLE
CI - Remove cached test results

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,6 +45,10 @@ pipeline {
             }
             steps {
                 sh """
+                # Delete the cached test results from previous executions.
+                # Otherwise, it the job fails, cached results may be reported.
+                rm -rf logs/
+
                 ./run.sh --validate-prereq --platform "${params.PLATFORM}"
                 """
 


### PR DESCRIPTION
The tests results of a job saved to a volume that mapped to the
container that is used for the testing.
If the job fails, the results from the previous job could be reported.
To prevent it, delete the old tests results at the beggining of the job.