### PR TITLE
Add downstream subctl binary use

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
         string(name: 'OC_CLUSTER_USER', defaultValue: '', description: 'ACM Hub username')
         string(name: 'OC_CLUSTER_PASS', defaultValue: '', description: 'ACM Hub password')
         extendedChoice(name: 'PLATFORM', description: 'The managed clusters platform that should be tested',
-            value: 'aws,gcp,azure', defaultValue: 'aws,gcp,azure', multiSelectDelimiter: ',', type: 'PT_CHECKBOX')
+            value: 'aws,gcp,azure,openstack', defaultValue: 'aws,gcp,azure,openstack', multiSelectDelimiter: ',', type: 'PT_CHECKBOX')
         booleanParam(name: 'GLOBALNET', defaultValue: true, description: 'Deploy Globalnet on Submariner')
         string(name: 'VERSION', defaultValue: '', description: 'Define specific version of Submariner to be installed')
         booleanParam(name: 'DOWNSTREAM', defaultValue: true, description: 'Deploy downstream version of Submariner')
@@ -45,10 +45,6 @@ pipeline {
             }
             steps {
                 sh """
-                # Delete the cached test results from previous executions.
-                # Otherwise, it the job fails, cached results may be reported.
-                rm -rf logs/
-
                 ./run.sh --validate-prereq --platform "${params.PLATFORM}"
                 """
 
@@ -123,8 +119,15 @@ pipeline {
                 }
             }
             steps {
+                script {
+                    DOWNSTREAM = ""
+                    if (params.DOWNSTREAM) {
+                        DOWNSTREAM = "--downstream"
+                    }
+                }
+
                 sh """
-                ./run.sh --test --platform "${params.PLATFORM}"
+                ./run.sh --test --platform "${params.PLATFORM}" $DOWNSTREAM
                 """
             }
         }

--- a/lib/prerequisites.sh
+++ b/lib/prerequisites.sh
@@ -96,32 +96,51 @@ function fetch_submariner_addon_version() {
 function get_subctl_for_testing() {
     INFO "Installing subctl client"
 
+    local image_prefix
     local subctl_version
     local subctl_download_url
+    local subctl_archive
     local subctl_bin
     subctl_version=$(fetch_submariner_addon_version)
 
-    if [[ "$subctl_version" == "v0.11"*  ]]; then
-        subctl_download_url="$SUBCTL_URL_DOWNLOAD/download/$subctl_version/subctl-$subctl_version-linux-amd64.tar.xz"
+    if [[ "$DOWNSTREAM" == "true" ]]; then
+        INFO "Download downstream subctl binary for testing"
+
+        if [[ "$subctl_version" == "v0.11"* ]]; then
+            image_prefix="$REGISTRY_IMAGE_PREFIX_TECH_PREVIEW"
+        else
+            image_prefix="$REGISTRY_IMAGE_PREFIX"
+        fi
+        subctl_download_url="$VPN_REGISTRY/$REGISTRY_IMAGE_IMPORT_PATH/$image_prefix-subctl-rhel8:$subctl_version"
+
+        oc image extract "$subctl_download_url" --path=/dist/subctl-*-linux-amd64.tar.xz:./ --confirm
     else
-        WARNING "Due to https://github.com/submariner-io/submariner-operator/issues/1977 devel version will be used"
-        subctl_download_url="$SUBCTL_UPSTREAM_URL/releases/download/subctl-devel/subctl-devel-linux-amd64.tar.xz"
+        INFO "Download upstream subctl binary for testing"
+
+        if [[ "$subctl_version" == "v0.11"*  ]]; then
+            subctl_download_url="$SUBCTL_URL_DOWNLOAD/download/$subctl_version/subctl-$subctl_version-linux-amd64.tar.xz"
+        else
+            WARNING "Due to https://github.com/submariner-io/submariner-operator/issues/1977 devel version will be used"
+            subctl_download_url="$SUBCTL_UPSTREAM_URL/releases/download/subctl-devel/subctl-devel-linux-amd64.tar.xz"
+        fi
+        wget -qO- "$subctl_download_url" -O subctl.tar.xz
     fi
 
     INFO "Submariner addon version - $subctl_version"
     INFO "Download subctl from - $subctl_download_url"
 
-    wget -qO- "$subctl_download_url" -O subctl.tar.xz
-    tar xfJ subctl.tar.xz --strip-components 1
+    subctl_archive=$(find . -maxdepth 1 -name "subctl*tar.xz")
+    tar xfJ "$subctl_archive" --strip-components 1
     subctl_bin=$(find . -maxdepth 1 -name "subctl*linux-amd64")
 
     mkdir -p "$HOME"/.local/bin
     cp "$subctl_bin" "$HOME"/.local/bin/subctl
-    rm -rf "$subctl_bin" subctl.tar.xz
+    rm -rf "$subctl_bin" "$subctl_archive"
 
     # Add local BIN dir to PATH
-    [[ ":$PATH:" = *":$HOME/.local/bin:"* ]] || export PATH="$HOME/.local/bin:$PATH"
-    INFO "Subctl $subctl_version has been donwload and placed under $HOME/.local/bin/"
+    [[ ":$PATH:" == *":$HOME/.local/bin:"* ]] || export PATH="$HOME/.local/bin:$PATH"
+    INFO "Subctl has been donwload and placed under $HOME/.local/bin/"
+    subctl version
 }
 
 function get_subctl_version() {


### PR DESCRIPTION
When downstream deployment is used, subctl binary will be fetched from
the downstream image as well to test the "show", "diagnose" and other
command alongside with the e2e tests.