### PR TITLE
Add "@post-release" condition tag support for job execution

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,6 +41,7 @@ pipeline {
                     environment name: 'TEST_TAGS', value: ''
                     environment name: 'TEST_TAGS', value: '@e2e'
                     environment name: 'TEST_TAGS', value: '@Submariner'
+                    environment name: 'TEST_TAGS', value: '@post-release'
                 }
             }
             steps {
@@ -105,6 +106,13 @@ pipeline {
                     if (params.DOWNSTREAM) {
                         DOWNSTREAM = "--downstream"
                     }
+
+                    // The '@post-release' tag meant to test post GA release
+                    // thus don't use the downstream tag.
+                    // Override the any state of the DOWNSTREAM param.
+                    if (params.TEST_TAGS == '@post-release') {
+                        DOWNSTREAM = ""
+                    }
                 }
 
                 sh """
@@ -123,6 +131,13 @@ pipeline {
                     DOWNSTREAM = ""
                     if (params.DOWNSTREAM) {
                         DOWNSTREAM = "--downstream"
+                    }
+
+                    // The '@post-release' tag meant to test post GA release
+                    // thus don't use the downstream tag.
+                    // Override the any state of the DOWNSTREAM param.
+                    if (params.TEST_TAGS == '@post-release') {
+                        DOWNSTREAM = ""
                     }
                 }
 

--- a/resources/submariner-config.yaml
+++ b/resources/submariner-config.yaml
@@ -14,6 +14,6 @@ spec:
     name: $MANAGED_CLUSTER_PLATFORM_SECRET
   subscriptionConfig:
     channel: $SUBMARINER_CHANNEL
-    source: submariner-catalog
+    source: $SUBMARINER_SOURCE
     sourceNamespace: openshift-marketplace
     startingCSV: $SUBMARINER_VERSION

--- a/run.sh
+++ b/run.sh
@@ -198,8 +198,8 @@ function deploy_submariner() {
         fi
 
         create_catalog_source
-        verify_package_manifest
     fi
+    verify_package_manifest
 
     create_clusterset
     assign_clusters_to_clusterset


### PR DESCRIPTION
The "@post-release" tag is used by the pipeline after the product
version released and performs deployment from the official registry
catalog.

This is used to validate that the product functioning correctly after
the release.

- Add support for the "@post-release" tag in Jenkinsfile
- Set the proper CatalogSource for submariner depends on the deployment
  method - official/downstream