### PR TITLE
Modify tests and logs naming convention

### DIFF
--- a/lib/gather_info.sh
+++ b/lib/gather_info.sh
@@ -144,11 +144,14 @@ function get_submariner_pods_logs() {
 function gather_cluster_info() {
     local kube_conf
     local cluster_log
+    local cluster_platform
 
     for cluster in $MANAGED_CLUSTERS; do
         LOG "Gather information for $cluster cluster"
         kube_conf="$LOGS/$cluster-kubeconfig.yaml"
-        cluster_log="$DEBUG_LOGS/$cluster.log"
+        cluster_platform=$(oc -n "$cluster" get clusterdeployment \
+            "$cluster" -o jsonpath='{.metadata.labels.cloud}')
+        cluster_log="$DEBUG_LOGS/${cluster_platform}_cluster.log"
         # The LOG_PATH env is set to append the LOG
         # messages into the log files.
         LOG_PATH="$cluster_log"

--- a/lib/submariner_test.sh
+++ b/lib/submariner_test.sh
@@ -18,6 +18,7 @@ function execute_submariner_tests() {
     # Subctl E2E tests are working with 2 clusters only at a time
     local primary_test_cluster
     local secondary_test_cluster
+    local tests_basename
 
     primary_test_cluster=$(echo "$MANAGED_CLUSTERS" | head -n 1)
 
@@ -27,45 +28,77 @@ function execute_submariner_tests() {
         fi
 
         secondary_test_cluster="$cluster"
+        tests_basename=$(combine_tests_basename "$primary_test_cluster" "$secondary_test_cluster")
 
         INFO "Running tests between $primary_test_cluster and $secondary_test_cluster clusters"
         export KUBECONFIG="$LOGS/$primary_test_cluster-kubeconfig.yaml:$LOGS/$secondary_test_cluster-kubeconfig.yaml"
 
         INFO "Show all Submariner information"
         subctl show all 2>&1 \
-            | tee  "$TESTS_LOGS/subctl_show_all_${primary_test_cluster}_${secondary_test_cluster}.log" \
+            | tee  "$TESTS_LOGS/${tests_basename}_subctl_show_all.log" \
             || add_test_error $?
 
         INFO "Execute diagnose all tests"
         subctl diagnose all 2>&1 \
-            | tee "$TESTS_LOGS/subctl_diagnose_all_${primary_test_cluster}_${secondary_test_cluster}.log" \
+            | tee "$TESTS_LOGS/${tests_basename}_subctl_diagnose_all.log" \
             || add_test_error $?
 
         INFO "Execute diagnose firewall inter-cluster tests"
         subctl diagnose firewall inter-cluster \
             "$LOGS/$primary_test_cluster-kubeconfig.yaml" \
             "$LOGS/$secondary_test_cluster-kubeconfig.yaml" 2>&1 \
-            |  tee "$TESTS_LOGS/subctl_firewall_tests_${primary_test_cluster}_${secondary_test_cluster}.log" \
+            |  tee "$TESTS_LOGS/${tests_basename}_subctl_firewall_tests.log" \
             || add_test_error $?
 
         INFO "Execute E2E tests"
         # Due to https://github.com/submariner-io/submariner-operator/issues/1977
         if subctl verify --help | grep -q --no-messages junit-report; then
             subctl verify --only service-discovery,connectivity --verbose \
-                --junit-report "$TESTS_LOGS/submariner_e2e_${primary_test_cluster}_${secondary_test_cluster}.xml" \
+                --junit-report "$TESTS_LOGS/${tests_basename}_e2e_junit.xml" \
                 --kubecontexts "$primary_test_cluster,$secondary_test_cluster" 2>&1 \
-                | tee "$TESTS_LOGS/subctl_e2e_tests_${primary_test_cluster}_${secondary_test_cluster}.log" \
+                | tee "$TESTS_LOGS/${tests_basename}_subctl_e2e_tests.log" \
                 || add_test_error $?
         else
             subctl verify --only service-discovery,connectivity --verbose \
                 --kubecontexts "$primary_test_cluster,$secondary_test_cluster" 2>&1 \
-                | tee "$TESTS_LOGS/subctl_e2e_tests_${primary_test_cluster}_${secondary_test_cluster}.log" \
+                | tee "$TESTS_LOGS/${tests_basename}_subctl_e2e_tests.log" \
                 || add_test_error $?
         fi
     done
     unset KUBECONFIG
     INFO "Tests execution finished"
     INFO "All the logs are placed within the $TESTS_LOGS directory"
+}
+
+function combine_tests_basename() {
+    local primary_cluster="$1"
+    local secondary_cluster="$2"
+    local acm_ver
+    local subm_ver
+    local primary_cl_platform
+    local secondary_cl_platform
+    local globalnet
+    local globalnet_state=""
+
+    acm_ver=$(oc get multiclusterhub -A -o jsonpath='{.items[0].status.currentVersion}')
+    subm_ver=$(KUBECONFIG="$LOGS/$primary_cluster-kubeconfig.yaml" \
+        oc -n submariner-operator get subs submariner \
+        -o jsonpath='{.status.currentCSV}' | grep -Po '(?<=submariner.v)[^)]*')
+    primary_cl_platform=$(oc -n "$primary_cluster" get clusterdeployment \
+        "$primary_cluster" -o jsonpath='{.metadata.labels.cloud}')
+    secondary_cl_platform=$(oc -n "$secondary_cluster" get clusterdeployment \
+        "$secondary_cluster" -o jsonpath='{.metadata.labels.cloud}')
+
+    globalnet_state=$(KUBECONFIG="$LOGS/$primary_cluster-kubeconfig.yaml" \
+        oc -n submariner-operator get pods -l=app=submariner-globalnet \
+        --no-headers=true -o custom-columns=NAME:".metadata.name")
+    if [[ -z "$globalnet_state" ]]; then
+        globalnet="NonGlobalnet"
+    else
+        globalnet="Globalnet"
+    fi
+
+    echo "ACM-${acm_ver}-Submariner-${subm_ver}-${primary_cl_platform}-${secondary_cl_platform}-${globalnet}"
 }
 
 # When one of the tests fails, add the error note to a global variable.


### PR DESCRIPTION
For the easy of understanding, modify the naming convention of the
clusters to include the name of the platform (cloud) that the cluster
runs on.

The naming convention will be used as well to identify the testing
scenario of the e2e test suite.
The example of the test file name:
ACM-2.5.1-Submariner-0.12.1-AWS-GCP-Globalnet_e2e_junit.xml