### PR TITLE
Add security label to created namespace

### DIFF
--- a/resources/namespace.yaml
+++ b/resources/namespace.yaml
@@ -3,3 +3,7 @@ kind: Namespace
 metadata:
   name: "$TEST_NAMESPACE"
   annotations: {}
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged


### PR DESCRIPTION
Starting with Kubernetes 1.23, the Pod Security admission controller
expects namespaces to have security labels.
Without these, you will see warnings in subctl's output.
Subctl should work fine, but you can avoid the warnings and ensure
correct behavior by adding these labels to the namespace.

- pod-security.kubernetes.io/enforce privileged
- pod-security.kubernetes.io/audit privileged
- pod-security.kubernetes.io/warn privileged