### PR TITLE
Modify search regex in Jenkinsfile for junit

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -173,7 +173,7 @@ pipeline {
     post {
         always {
             archiveArtifacts artifacts: "logs/**/*.*", followSymlinks: false, allowEmptyArchive: true
-            junit allowEmptyResults: true, testResults: "logs/**/*.xml"
+            junit allowEmptyResults: true, testResults: "logs/**/*junit.xml"
         }
     }
 }


### PR DESCRIPTION
After job finishes it outputs number of xml based files.
Some of the files are the output of junit tests results files and some
are the input for Polarion reporting files.

Modify the search regex for junit file for Jenkins junit tests results
display.