### PR TITLE
Remove manual cloud prepare for azure from version 0.13.0

### DIFF
--- a/lib/common/prerequisites.sh
+++ b/lib/common/prerequisites.sh
@@ -72,10 +72,6 @@ function verify_prerequisites_tools() {
     verify_ocp_clients
     verify_yq
     verify_jq
-
-    if [[ "$PLATFORM" =~ "azure" && "$RUN_COMMAND" =~ ("all"|"deploy") ]]; then
-        verify_az_cli
-    fi
 }
 
 

--- a/run.sh
+++ b/run.sh
@@ -185,17 +185,23 @@ function prepare() {
 }
 
 function deploy_submariner() {
-    if [[ "$PLATFORM" =~ "azure" ]]; then
-        INFO "Perform manual cloud prepare for Azure.
-        Replace when patch is merged:
-        https://github.com/submariner-io/cloud-prepare/pull/203"
-        prepare_azure_cloud
-    fi
-
     if [[ -n "$SUBMARINER_VERSION_INSTALL" ]]; then
         validate_given_submariner_version
     else
         select_submariner_version_and_channel_to_deploy
+    fi
+
+    if [[ "$PLATFORM" =~ "azure" ]]; then
+        # Starting from submariner 0.13.0, cloud prepare
+        # is done automatically.
+        # Only older versions require manual steps.
+        local azure_cloud_support="0.13.0"
+        version_state=$(validate_version "$azure_cloud_support" "$SUBMARINER_VERSION_INSTALL")
+        if [[ "$version_state" == "not_valid" ]]; then
+            INFO "Perform manual cloud prepare for Azure"
+            # verify_az_cli
+            # prepare_azure_cloud
+        fi
     fi
 
     if [[ "$DOWNSTREAM" == 'true' ]]; then


### PR DESCRIPTION
Starting from submariner version 0.13.0, cloud prepare for azure cloud
is done automatically.

Keep the manual steps for the older versions.