### PR TITLE
Add random gateway deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,15 @@ export OC_CLUSTER_PASS=<password of the cluster user>
                              the Submariner gateway HA will be enabled automatically.
                              (Optional)
 
+    --subm-gateway-random  - Set the deployment flow to randomize the gateway deployment
+                             between clusters. When used, the flow will deploy 2 gateway nodes
+                             on the first cluster and 1 gateway node on all other clusters.
+                             Used by the internal QE flow to test random states of gateways.
+                             Note - The use of this flag will ignore the "--subm-gateway-count"
+                             flag.
+                             (Optional)
+                             By default - false
+
     Reporting arguments:
     --------------------
     --polarion-vars-file   - A path to the file that contains Polarion details.

--- a/lib/common/helper_functions.sh
+++ b/lib/common/helper_functions.sh
@@ -132,6 +132,15 @@ function usage() {
                              the Submariner gateway HA will be enabled automatically.
                              (Optional)
 
+    --subm-gateway-random  - Set the deployment flow to randomize the gateway deployment
+                             between clusters. When used, the flow will deploy 2 gateway nodes
+                             on the first cluster and 1 gateway node on all other clusters.
+                             Used by the internal QE flow to test random states of gateways.
+                             Note - The use of this flag will ignore the "--subm-gateway-count"
+                             flag.
+                             (Optional)
+                             By default - false
+
     Reporting arguments:
     --------------------
     --polarion-vars-file   - A path to the file that contains Polarion details.
@@ -299,7 +308,8 @@ function print_selected_options() {
 
         Submariner IPSEC NATT Port: $SUBMARINER_IPSEC_NATT_PORT
         Submariner cable driver: $SUBMARINER_CABLE_DRIVER
-        Submariner gateway count: $SUBMARINER_GATEWAY_COUNT"
+        Submariner gateway count: $SUBMARINER_GATEWAY_COUNT
+        Submariner gateway random: $SUBMARINER_GATEWAY_RANDOM"
         echo -e "\n###############################\n"
     fi
 }

--- a/lib/submariner_deploy/submariner_deploy.sh
+++ b/lib/submariner_deploy/submariner_deploy.sh
@@ -19,10 +19,15 @@ function prepare_clusters_for_submariner() {
         catalog_source="submariner-catalog"
     fi
 
+    if [[ "$SUBMARINER_GATEWAY_RANDOM" == "true" ]]; then
+        SUBMARINER_GATEWAY_COUNT=2
+    fi
+
     for cluster in $MANAGED_CLUSTERS; do
         creds=$(get_cluster_credential_name "$cluster")
         INFO "Using $creds credentials for $cluster cluster"
-        INFO "Prepare cloud for cluster $cluster"
+        INFO "Apply SubmarinerConfig on cluster $cluster"
+        INFO "Use $SUBMARINER_GATEWAY_COUNT for $cluster cluster"
 
         CL="$cluster" CRED="$creds" SUBM_CHAN="$submariner_channel" \
             SUBM_VER="$submariner_version" NS="$catalog_ns" \
@@ -37,6 +42,10 @@ function prepare_clusters_for_submariner() {
             | .spec.subscriptionConfig.sourceNamespace = env(NS)
             | .spec.subscriptionConfig.startingCSV = env(SUBM_VER)' \
             "$SCRIPT_DIR/manifests/submariner-config.yaml" | oc apply -f -
+
+        if [[ "$SUBMARINER_GATEWAY_RANDOM" == "true" ]]; then
+            SUBMARINER_GATEWAY_COUNT=1
+        fi
     done
 }
 

--- a/run.sh
+++ b/run.sh
@@ -82,6 +82,10 @@ export SUBMARINER_CHANNEL_RELEASE=""
 export SUBMARINER_IPSEC_NATT_PORT=4505
 export SUBMARINER_CABLE_DRIVER="libreswan"
 export SUBMARINER_GATEWAY_COUNT=1
+# When set to true, the deployment will set 2 gateways
+# on first cluster and 1 gateway on other clusters
+# Used by the testing pipeline
+export SUBMARINER_GATEWAY_RANDOM="false"
 # Official RedHat registry
 export OFFICIAL_REGISTRY="registry.redhat.io"
 export STAGING_REGISTRY="registry.stage.redhat.io"
@@ -334,6 +338,12 @@ function parse_arguments() {
             --subm-gateway-count)
                 if [[ -n "$2" ]]; then
                     SUBMARINER_GATEWAY_COUNT="$2"
+                    shift 2
+                fi
+                ;;
+            --subm-gateway-random)
+                if [[ -n "$2" ]]; then
+                    SUBMARINER_GATEWAY_RANDOM="$2"
                     shift 2
                 fi
                 ;;


### PR DESCRIPTION
When random gateway is used on deployment,
apply 2 gateways on first cluster and 1 gateway on other clusters.
Used by the testing pipeline to test over gateway failover flows.