### PR TITLE
Detect and use only the first pool claim clusterset

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -164,6 +164,7 @@ function validate_prerequisites() {
     verify_prerequisites_tools
     login_to_cluster "hub"
     check_clusters_deployment
+    check_for_claim_cluster_with_pre_set_clusterset
 
     mch_ver=$(fetch_multiclusterhub_version)
     echo "MultiClusterHub version:"


### PR DESCRIPTION
When multiple pool claim clusters available and each pool claim cluster
has defined clusterset, the deployment will fail as it will not be able
to assign all the claim clusters with different clusterset to specific
clusterset.

If pool claim clusterset detected, use only the first one and exclude
other clusters from eecution to prevent deployment failure.