### PR TITLE
Fix cluster assign to clusterset step

### DIFF
--- a/lib/common/gather_info.sh
+++ b/lib/common/gather_info.sh
@@ -99,9 +99,13 @@ function get_submariner_addon_log() {
     addon_pod=$(KUBECONFIG="$kube_conf" oc -n "$SUBMARINER_NS" \
         get pods -l app=submariner-addon --no-headers=true \
         -o custom-columns=NAME:.metadata.name)
-    KUBECONFIG="$kube_conf" oc -n "$SUBMARINER_NS" \
-        logs "$addon_pod" >> "${cluster_log}_submariner_addon.log" \
-        || echo "No logs found for pod $addon_pod" > "${cluster_log}_submariner_addon.log"
+
+    if [[ -n "$addon_pod" ]]; then
+        KUBECONFIG="$kube_conf" oc -n "$SUBMARINER_NS" \
+            logs "$addon_pod" >> "${cluster_log}_submariner_addon.log"
+    else
+        echo "No addon pod has been found" > "${cluster_log}_submariner_addon.log"
+    fi
 }
 
 function gather_cluster_info() {


### PR DESCRIPTION
- After the clusters to a clusterset, the content of the clusterset is
  checked to ensure all the requested clusters assigned to a clusterset.
  Fix the check step to ensure that only requested clusters will be
  checked within the clusterset.

- Check for existence of the submariner-addon pod before gather it's
  logs.