### PR TITLE
Do not disable disableAllDefaultSources of the cluster

### DIFF
--- a/lib/submariner_prepare/downstream_mirroring_workaround.sh
+++ b/lib/submariner_prepare/downstream_mirroring_workaround.sh
@@ -378,10 +378,6 @@ function import_images_into_local_registry() {
     for cluster in $MANAGED_CLUSTERS; do
         local kube_conf="$LOGS/$cluster-kubeconfig.yaml"
 
-        INFO "Disable the default remote OperatorHub sources for OLM"
-        KUBECONFIG="$kube_conf" oc patch OperatorHub cluster --type json \
-            -p '[{"op": "add", "path": "/spec/disableAllDefaultSources", "value": true}]'
-
         INFO "Import Submariner images into cluster $cluster"
         for image in \
           $SUBM_IMG_BUNDLE \


### PR DESCRIPTION
During deployment of Submariner, the disableAllDefaultSources is set to
true, but it prevents from proper execution of other squads on the
environment.

Do not set the disableAllDefaultSources to "true" on cluster.