### PR TITLE
Add support for version 0.13.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ The versions of ACM Hub and Submariner defined in `run.sh` file and used during 
 | 2.4.*         | 0.11.2     |
 | 2.5.0 / 2.5.1 | 0.12.1     |
 | 2.5.2         | 0.12.2     |
-| 2.6.0         | 0.13.0     |
+| 2.6.0 / 2.6.1 | 0.13.0     |
+| 2.6.2         | 0.13.1     |
 
 ## Execution
 Execution of deployment, testing and reporting requires connection details to the ACM HUB cluster.  
@@ -43,7 +44,7 @@ export OC_CLUSTER_URL=<hub cluster url>
 export OC_CLUSTER_USER=<cluster user name (kubeadmin)>
 export OC_CLUSTER_PASS=<password of the cluster user>
 
-./run.sh --deploy --platform aws,gcp --downstream --globalnet true
+./run.sh --deploy --platform aws,gcp --downstream true --globalnet true
 ```
 
 ### Command arguments
@@ -80,12 +81,12 @@ export OC_CLUSTER_PASS=<password of the cluster user>
                              If not specified, submariner version will be chosen
                              based of the ACM hub support
 
-    --downstream           - Use the flag if downsteram images should be used.
+    --downstream           - Use the flag if downstream images should be used.
                              Submariner images could be sourced from two places:
                                * Official Red Hat ragistry - registry.redhat.io
                                * Downstream Quay registry - brew.registry.redhat.io
                              (Optional)
-                             If flag is not used, official registry will be used
+                             By default - false
 
     --mirror               - Use local ocp registry.
                              Due to https://issues.redhat.com/browse/RFE-1608,

--- a/lib/common/helper_functions.sh
+++ b/lib/common/helper_functions.sh
@@ -87,12 +87,12 @@ function usage() {
                              If not specified, submariner version will be chosen
                              based of the ACM hub support
 
-    --downstream           - Use the flag if downsteram images should be used.
+    --downstream           - Use the flag if downstream images should be used.
                              Submariner images could be sourced from two places:
                                * Official Red Hat ragistry - registry.redhat.io
                                * Downstream Quay registry - brew.registry.redhat.io
                              (Optional)
-                             If flag is not used, official registry will be used
+                             By default - false
 
     --mirror               - Use local ocp registry.
                              Due to https://issues.redhat.com/browse/RFE-1608,

--- a/run.sh
+++ b/run.sh
@@ -59,6 +59,12 @@ declare -A ACM_2_6=(
     [channel]='stable'
 )
 export ACM_2_6
+declare -A ACM_2_6_2=(
+    [acm_version]='2.6.2'
+    [submariner_version]='0.13.1'
+    [channel]='stable'
+)
+export ACM_2_6_2
 # Declare array of COMPONENTS_VERSIONS of associative arrays
 export COMPONENT_VERSIONS=("${!ACM@}")
 
@@ -309,8 +315,10 @@ function parse_arguments() {
                 fi
                 ;;
             --downstream)
-                DOWNSTREAM="true"
-                shift
+                if [[ -n "$2" ]]; then
+                    DOWNSTREAM="$2"
+                    shift 2
+                fi
                 ;;
             --mirror)
                 if [[ -n "$2" ]]; then


### PR DESCRIPTION
- Add pipeline support for submariner version 0.13.1

- Fix "downstream" argument. It should use a boolean definition - "true"/"false".