### PR TITLE
Fetch Submariner Addon version without suffix

### DIFF
--- a/lib/common/prerequisites.sh
+++ b/lib/common/prerequisites.sh
@@ -107,7 +107,7 @@ function get_subctl_for_testing() {
     local subctl_download_url
     local subctl_archive
     local subctl_bin
-    subctl_version=$(fetch_submariner_addon_version)
+    subctl_version=$(fetch_submariner_addon_version | cut -d '-' -f1)
 
     if [[ "$DOWNSTREAM" == "true" ]]; then
         INFO "Download downstream subctl binary for testing"
@@ -118,6 +118,7 @@ function get_subctl_for_testing() {
             image_prefix="$REGISTRY_IMAGE_PREFIX"
         fi
         subctl_download_url="$VPN_REGISTRY/$REGISTRY_IMAGE_IMPORT_PATH/$image_prefix-subctl-rhel8:$subctl_version"
+        INFO "Download subctl from - $subctl_download_url"
 
         oc image extract --insecure=true "$subctl_download_url" --path=/dist/subctl-*-linux-amd64.tar.xz:./ --confirm
     else


### PR DESCRIPTION
When submariner version released with the CVE security fix, it has a suffix number for the version.
For example: v0.13.1-4.1654396857p

Remove the suffix in order to be able to pull the nettest image suring the testing phase.