### PR TITLE
Add support for 0.14.0 version and minor fixes

### DIFF
--- a/lib/submariner_deploy/submariner_deploy.sh
+++ b/lib/submariner_deploy/submariner_deploy.sh
@@ -27,7 +27,7 @@ function prepare_clusters_for_submariner() {
         creds=$(get_cluster_credential_name "$cluster")
         INFO "Using $creds credentials for $cluster cluster"
         INFO "Apply SubmarinerConfig on cluster $cluster"
-        INFO "Use $SUBMARINER_GATEWAY_COUNT for $cluster cluster"
+        INFO "Use $SUBMARINER_GATEWAY_COUNT gateway node for $cluster cluster"
 
         CL="$cluster" CRED="$creds" SUBM_CHAN="$submariner_channel" \
             SUBM_VER="$submariner_version" NS="$catalog_ns" \

--- a/lib/submariner_prepare/downstream_prepare.sh
+++ b/lib/submariner_prepare/downstream_prepare.sh
@@ -38,7 +38,6 @@ function get_latest_iib() {
     local latest_builds_number=5
     local rows=$((latest_builds_number * 5))
     local number_of_days=30
-    local delta=$((number_of_days * 86400))  # 1296000 = 15 days * 86400 seconds
 
     # The query component changed started from submariner version 0.12.* and for older version remain the same
     # For 0.12.* the component name is - "cvp-teamredhatadvancedclustermanagement"
@@ -49,7 +48,9 @@ function get_latest_iib() {
     fi
 
     # Loop over the build issuers and fetch results for each issuer.
-    for issuer in "freshmaker" "contra/pipeline"; do
+    for issuer in "contra/pipeline" "freshmaker"; do
+        local delta=$((number_of_days * 86400))  # 1296000 = 15 days * 86400 seconds
+
         # In order to separate the variables, create a variable for each issuer.
         # But since bash unable to use "/" sign as part of the variable name,
         # rename the variable for "contra/pipeline" key to "$pipeline_var".
@@ -71,9 +72,6 @@ function get_latest_iib() {
         declare "$issuer_var"="$index_images"
 
         if [[ "$index_images" == "null" ]]; then
-            WARNING "Failed to retrieve IIB by using the last $number_of_days days.
-            Retrying with the number of days multiplied $number_of_days days x6."
-
             delta=$((delta * 6))
             umb_output=$(curl --retry 30 --retry-delay 5 -k -Ls \
                 "${umb_url}&rows_per_page=${rows}&delta=${delta}&contains=${bundle_name}-container-v${submariner_version}")

--- a/lib/submariner_prepare/validate_acm_readiness.sh
+++ b/lib/submariner_prepare/validate_acm_readiness.sh
@@ -142,8 +142,11 @@ function validate_non_globalnet_clusters() {
     INFO "The following clusters have non overlapping CIDR:
     $clusters
     Overriding MANAGED_CLUSTERS list"
-    WARNING "A Non Globalnet deployment selected
-    The following clusters were discarded due to overlapping CIDR: $discarded_clusters"
+
+    if [[ -n "$discarded_clusters" ]]; then
+        WARNING "A Non Globalnet deployment selected
+        The following clusters were discarded due to overlapping CIDR: $discarded_clusters"
+    fi
     MANAGED_CLUSTERS="$clusters"
 
     for platform in $MANAGED_CLUSTERS; do

--- a/variables
+++ b/variables
@@ -52,6 +52,18 @@ declare -A ACM_2_5_3=(
     [channel]='stable'
 )
 export ACM_2_5_3
+declare -A ACM_2_5_4=(
+    [acm_version]='2.5.4'
+    [submariner_version]='0.12.2'
+    [channel]='stable'
+)
+export ACM_2_5_4
+declare -A ACM_2_5_5=(
+    [acm_version]='2.5.5'
+    [submariner_version]='0.12.2'
+    [channel]='stable'
+)
+export ACM_2_5_5
 declare -A ACM_2_6=(
     [acm_version]='2.6'
     [submariner_version]='0.13.0'
@@ -64,6 +76,12 @@ declare -A ACM_2_6_2=(
     [channel]='stable'
 )
 export ACM_2_6_2
+declare -A ACM_2_7=(
+    [acm_version]='2.7'
+    [submariner_version]='0.14.0'
+    [channel]='stable'
+)
+export ACM_2_7
 # Declare array of COMPONENTS_VERSIONS of associative arrays
 export COMPONENT_VERSIONS=("${!ACM@}")
 


### PR DESCRIPTION
- Add support for versions:
  - 2.7.0 / 0.14.0
  - 2.5.4 / 0.12.2
  - 2.5.5 / 0.12.2

- During fetch of IIB, the "delta" variable should be rewritten during each loop to not double the result.

- Print "Non Globalnet" warning only when unmatched cluster is found.

- Fix the string that prints how many gateway nodes deployed.