### PR TITLE
Add ARO support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The following clusters platforms are supported by the Submariner Addon deploymen
 - [X] GCP
 - [X] Azure
 - [X] VMware
+- [X] ARO
 - [ ] OSP
 
 The user is able to define manually which platforms should be deployed and tested.  

--- a/lib/common/helper_functions.sh
+++ b/lib/common/helper_functions.sh
@@ -189,13 +189,31 @@ function login_to_cluster() {
     fi
 }
 
+# Fetch platform of the cluster
+function get_cluster_platform() {
+    local cluster="$1"
+    local cluster_platform
+
+    cluster_platform=$(oc get managedcluster "$cluster" \
+        -o jsonpath='{.status.clusterClaims[?(@.name == "platform.open-cluster-management.io")].value}')
+    echo "$cluster_platform"
+}
+
+# Fetch product of the cluster
+function get_cluster_product() {
+    local cluster="$1"
+    local cluster_product
+
+    cluster_product=$(oc get managedcluster "$cluster" \
+        -o jsonpath='{.status.clusterClaims[?(@.name == "product.open-cluster-management.io")].value}')
+    echo "$cluster_product"
+}
+
 # Fetch the name of the cloud credentials for the cluster
 function get_cluster_credential_name() {
-    local cluster
+    local cluster="$1"
     local platform_type
     local cluster_creds_name
-
-    cluster="$1"
 
     platform_type=$(oc get clusterdeployment -n "$cluster" -o json --no-headers=true \
                  -o custom-columns=PLATFORM:".metadata.labels.hive\.openshift\.io/cluster-platform")

--- a/lib/submariner_test/submariner_test.sh
+++ b/lib/submariner_test/submariner_test.sh
@@ -85,10 +85,8 @@ function combine_tests_basename() {
         oc -n submariner-operator get subs submariner \
         -o jsonpath='{.status.currentCSV}' \
         | grep -Po '(?<=submariner.v)[^)]*' | cut -d '-' -f1)
-    primary_cl_platform=$(oc -n "$primary_cluster" get clusterdeployment \
-        "$primary_cluster" -o jsonpath='{.metadata.labels.cloud}')
-    secondary_cl_platform=$(oc -n "$secondary_cluster" get clusterdeployment \
-        "$secondary_cluster" -o jsonpath='{.metadata.labels.cloud}')
+    primary_cl_platform=$(set_cluster_platform_for_test_report "$primary_cluster")
+    secondary_cl_platform=$(set_cluster_platform_for_test_report "$secondary_cluster")
 
     globalnet_state=$(KUBECONFIG="$LOGS/$primary_cluster-kubeconfig.yaml" \
         oc -n submariner-operator get pods -l=app=submariner-globalnet \
@@ -100,6 +98,19 @@ function combine_tests_basename() {
     fi
 
     echo "ACM-${acm_ver}-Submariner-${subm_ver}-${primary_cl_platform}-${secondary_cl_platform}-${globalnet}"
+}
+
+function set_cluster_platform_for_test_report() {
+    local cluster="$1"
+    local platform
+    local product
+
+    platform=$(get_cluster_platform "$cluster")
+    product=$(get_cluster_product "$cluster")
+    if [[ "$product" != "OpenShift" ]]; then
+        platform="$product"
+    fi
+    echo "$platform"
 }
 
 # When one of the tests fails, add the error note to a global variable.

--- a/manifests/submariner-config.yaml
+++ b/manifests/submariner-config.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   IPSecNATTPort: $IPSEC_NATT_PORT
   cableDriver: libreswan
+  loadBalancerEnable: false
   gatewayConfig:
     gateways: 1
     aws:

--- a/variables
+++ b/variables
@@ -13,7 +13,7 @@ export LOG_PATH=""
 export SUBCTL_URL_DOWNLOAD="https://github.com/submariner-io/releases/releases"
 export SUBCTL_UPSTREAM_URL="https://github.com/submariner-io/subctl"
 export PLATFORM="aws,gcp"  # Default platform definition
-export SUPPORTED_PLATFORMS="aws,gcp,azure,vsphere"  # Supported platform definition
+export SUPPORTED_PLATFORMS="aws,gcp,azure,vsphere,aro"  # Supported platform definition
 # Non critial failures will be stored into the variable
 # and printed at the end of the execution.
 # The testing will be performed,
@@ -137,6 +137,7 @@ export SUBM_IMG_NETWORK="submariner-networkplugin-syncer-rhel8"
 export SUBM_IMG_LIGHTHOUSE="lighthouse-agent-rhel8"
 export SUBM_IMG_COREDNS="lighthouse-coredns-rhel8"
 export SUBM_IMG_GLOBALNET="submariner-globalnet-rhel8"
+export SUBM_IMG_NETTEST_DOWNSTREAM="nettest-rhel8"
 export SUBM_IMG_NETTEST_UPSTREAM="nettest"
 export SUBM_IMG_NETTEST_PATH_UPSTREAM="quay.io/submariner"
 


### PR DESCRIPTION
- Add ARO support to submariner deployment.
- Add "loadBalancerEnable: true" parameter to SubmarinerConfig CR. Currently, parameter should be used by ARO and ROSA clusters only.
- Import downstream nettest image starting from 0.13.2 version.
- Add "set_cluster_platform_for_test_report" function to properly identify platform for test report file name.
- Add "get_cluster_platform" and "get_cluster_product" functions to detect information from both cluster types - imported and hive based.
- ARO and ROSA clusters skip cloud-prepare step, so passing "null" value as an input to cloud credentials of the cluster.