### PR TITLE
Run validation on imported clusters

### DIFF
--- a/lib/common/helper_functions.sh
+++ b/lib/common/helper_functions.sh
@@ -209,6 +209,26 @@ function get_cluster_product() {
     echo "$cluster_product"
 }
 
+# The function located cluster platform based
+# on the output of cluster platform and product.
+# Since ARO managed OCP based on Azure,
+# and ROSA managed OCP based on AWS,
+# those values defined in the product field.
+# So in case, the product field does not equal to "OpenShift",
+# it will be ARO or ROSA cluster and this value will be taken.
+function locate_cluster_platform() {
+    local cluster="$1"
+    local cluster_platform
+    local cluster_product
+
+    cluster_platform=$(get_cluster_platform "$cluster")
+    cluster_product=$(get_cluster_product "$cluster")
+    if [[ "$cluster_product" != "OpenShift" ]]; then
+        cluster_platform="$cluster_product"
+    fi
+    echo "$cluster_platform"
+}
+
 # Fetch the name of the cloud credentials for the cluster
 function get_cluster_credential_name() {
     local cluster="$1"

--- a/lib/submariner_test/submariner_test.sh
+++ b/lib/submariner_test/submariner_test.sh
@@ -85,8 +85,8 @@ function combine_tests_basename() {
         oc -n submariner-operator get subs submariner \
         -o jsonpath='{.status.currentCSV}' \
         | grep -Po '(?<=submariner.v)[^)]*' | cut -d '-' -f1)
-    primary_cl_platform=$(set_cluster_platform_for_test_report "$primary_cluster")
-    secondary_cl_platform=$(set_cluster_platform_for_test_report "$secondary_cluster")
+    primary_cl_platform=$(locate_cluster_platform "$primary_cluster")
+    secondary_cl_platform=$(locate_cluster_platform "$secondary_cluster")
 
     globalnet_state=$(KUBECONFIG="$LOGS/$primary_cluster-kubeconfig.yaml" \
         oc -n submariner-operator get pods -l=app=submariner-globalnet \
@@ -98,19 +98,6 @@ function combine_tests_basename() {
     fi
 
     echo "ACM-${acm_ver}-Submariner-${subm_ver}-${primary_cl_platform}-${secondary_cl_platform}-${globalnet}"
-}
-
-function set_cluster_platform_for_test_report() {
-    local cluster="$1"
-    local platform
-    local product
-
-    platform=$(get_cluster_platform "$cluster")
-    product=$(get_cluster_product "$cluster")
-    if [[ "$product" != "OpenShift" ]]; then
-        platform="$product"
-    fi
-    echo "$platform"
 }
 
 # When one of the tests fails, add the error note to a global variable.

--- a/run.sh
+++ b/run.sh
@@ -78,6 +78,7 @@ function prepare() {
     login_to_cluster "hub"
     check_clusters_deployment
     check_for_claim_cluster_with_pre_set_clusterset
+    INFO "Fetch the kubeconfigs for selected clusters only"
     fetch_kubeconfig_contexts_and_pass
     validate_internal_registry
 }


### PR DESCRIPTION
When a non globalnet submariner deployment is made, the flow checks for the cluster network configuration and compares to other clusters. If conflicting ranges detected, one of the cluster excluded from the deployment flow to prevent conflict during submariner deployment.

As ARO and ROSA could be only imported and not created by hive, an approach of fetching clusters information should change.

Fetch networking information directly from the clusters instead of clusterdeployment resource as imported cluster as not available there.