### PR TITLE
Fix "post-release" flow in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -116,7 +116,7 @@ pipeline {
                     // thus don't use the downstream tag.
                     // Override the any state of the DOWNSTREAM param.
                     if (params.TEST_TAGS == '@post-release') {
-                        DOWNSTREAM = ""
+                        DOWNSTREAM = "--downstream false"
                     }
                 }
 
@@ -142,7 +142,7 @@ pipeline {
                     // thus don't use the downstream tag.
                     // Override the any state of the DOWNSTREAM param.
                     if (params.TEST_TAGS == '@post-release') {
-                        DOWNSTREAM = ""
+                        DOWNSTREAM = "--downstream false"
                     }
                 }
 


### PR DESCRIPTION
The "post-release" flow checks the release after GA.
Use "--downstream false" flag during the deployment.