### PR TITLE
Update GH action trigger

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -2,9 +2,9 @@ name: 'Test code with Shellcheck'
 
 on:
   push:
-    branches: [ main, devel ]
+    branches: [ main, devel, 'release*' ]
   pull_request:
-    branches: [ main, devel ]
+    branches: [ main, devel, 'release*' ]
 
 jobs:
   shellcheck:


### PR DESCRIPTION
The GitHub Action should be triggered on the 'main', 'devel' and all the 'release*' branches.