### PR TITLE
Add version support ACM 2.5.6 / Submariner 0.12.3

### DIFF
--- a/variables
+++ b/variables
@@ -64,6 +64,12 @@ declare -A ACM_2_5_5=(
     [channel]='stable'
 )
 export ACM_2_5_5
+declare -A ACM_2_5_6=(
+    [acm_version]='2.5.6'
+    [submariner_version]='0.12.3'
+    [channel]='stable'
+)
+export ACM_2_5_6
 declare -A ACM_2_6=(
     [acm_version]='2.6'
     [submariner_version]='0.13.0'


### PR DESCRIPTION
Add support for the following version:
ACM 2.5.6 / Submariner 0.12.3