### PR TITLE
Fix post release deployment

### DIFF
--- a/lib/common/prerequisites.sh
+++ b/lib/common/prerequisites.sh
@@ -105,9 +105,10 @@ function get_subctl_for_testing() {
     else
         INFO "Download upstream subctl binary for testing"
 
-        WARNING "Due to https://github.com/submariner-io/submariner-operator/issues/1977 devel version will be used"
-        subctl_download_url="$SUBCTL_UPSTREAM_URL/releases/download/subctl-devel/subctl-devel-linux-amd64.tar.xz"
-        wget -qO- "$subctl_download_url" -O subctl.tar.xz
+        subctl_download_url="$OFFICIAL_REGISTRY/$REGISTRY_IMAGE_PREFIX/subctl-rhel8:$subctl_version"
+        INFO "Download subctl from - $subctl_download_url"
+
+        oc image extract "$subctl_download_url" --path=/dist/subctl-*-linux-amd64.tar.xz:./ --confirm
     fi
 
     INFO "Submariner addon version - $subctl_version"

--- a/lib/submariner_deploy/submariner_deploy.sh
+++ b/lib/submariner_deploy/submariner_deploy.sh
@@ -17,6 +17,11 @@ function prepare_clusters_for_submariner() {
 
     if [[ "$DOWNSTREAM" == 'true' ]]; then
         catalog_source="submariner-catalog"
+    else
+        # When deploying from the official source, OLM will choose the right version
+        # automatically based on the PackageManifest fetches from the official CatalogSource.
+        # Thus the "startingCSV" parameter will be supplied as "null".
+        submariner_version="null"
     fi
 
     if [[ "$SUBMARINER_GATEWAY_RANDOM" == "true" ]]; then


### PR DESCRIPTION
- During "post-release" deployment testing, "startingCSV" parameter should not be defined as OLM chooces which version should be deployed based on the PackageManifest and "redhat-operators" CatalogSource.

- Subctl binary should be fetched from the official registry.