### PR TITLE
Modify submariner version fetch for test

### DIFF
--- a/lib/common/prerequisites.sh
+++ b/lib/common/prerequisites.sh
@@ -66,19 +66,7 @@ function fetch_submariner_addon_version() {
     local sub_cluster_ns
     local sub_version
 
-    sub_cluster_ns=$(oc get clusterdeployment -A \
-        --selector=cluster.open-cluster-management.io/clusterset="$CLUSTERSET" \
-        -o jsonpath='{range.items[?(@.status.powerState=="Running")]}{.metadata.namespace}{"\n"}{end}' \
-        | head -n 1)
-    # ACM 2.4.x missing ".status.powerState", which is added in 2.5.x
-    # In case first quesry return empty var, execute a different query
-    if [[ -z "$sub_cluster_ns" ]]; then
-        sub_cluster_ns=$(oc get clusterdeployment -A \
-            --selector=cluster.open-cluster-management.io/clusterset="$CLUSTERSET" \
-            -o jsonpath='{range.items[?(@.status.conditions[0].reason=="Running")]}{.metadata.namespace}{"\n"}{end}' \
-            | head -n 1)
-    fi
-
+    sub_cluster_ns=$(echo "$MANAGED_CLUSTERS" | head -n 1)
     sub_version=$(oc get managedclusteraddon/submariner -n "$sub_cluster_ns" \
                     -o jsonpath='{.status.conditions[?(@.type == "SubmarinerAgentDegraded")].message}' \
                     | grep -Po '(?<=submariner.)[^)]*')


### PR DESCRIPTION
When downloading subctl binary for testing, we need to get the submariner addon version.

Currently, during the version fetch the first available cluster taken from the clusterset.
The possible problem could be, that the clusterset contains clusters beside the clusters with submariner deployment.
As a result, addon version could not be fetched.

Modify the function to get the first cluster from the "MANAGED_CLUSTERS" variable that contains submariner clusters instead of the first cluster from the clusterset.