### PR TITLE
[release-2.5] - Remove old versions dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,22 +15,23 @@ The following clusters platforms are supported by the Submariner Addon deploymen
 - [X] AWS
 - [X] GCP
 - [X] Azure
-- [X] VMware
 - [ ] OSP
 
 The user is able to define manually which platforms should be deployed and tested.  
 Multiple platforms should be separated by a comma.
 
 ## ACM Hub and Submariner versions
-The versions of ACM Hub and Submariner defined in `run.sh` file and used during the execution.
+Before deployment execution, switch to the relevant branch - release-2.6, release-2.7, etc...
 
-| ACM Hub       | Submariner |
-|---------------|------------|
-| 2.4.*         | 0.11.2     |
-| 2.5.0 / 2.5.1 | 0.12.1     |
-| 2.5.2         | 0.12.2     |
-| 2.6.0 / 2.6.1 | 0.13.0     |
-| 2.6.2         | 0.13.1     |
+| ACM Hub                       | Submariner |
+|-------------------------------|------------|
+| 2.4.*                         | 0.11.2     |
+| 2.5.0 / 2.5.1                 | 0.12.1     |
+| 2.5.2 / 2.5.3 / 2.5.4 / 2.5.5 | 0.12.2     |
+| 2.5.6                         | 0.12.3     |
+| 2.6.0 / 2.6.1                 | 0.13.0     |
+| 2.6.2 / 2.6.3                 | 0.13.1     |
+| 2.6.4                         | 0.13.2     |
 
 ## Execution
 Execution of deployment, testing and reporting requires connection details to the ACM HUB cluster.  
@@ -77,11 +78,6 @@ export OC_CLUSTER_PASS=<password of the cluster user>
                              Separate multiple platforms by comma
                              (Optional)
                              By default - aws,gcp
-
-    --version              - Specify Submariner version to be deployed
-                             (Optional)
-                             If not specified, submariner version will be chosen
-                             based of the ACM hub support
 
     --downstream           - Use the flag if downstream images should be used.
                              Submariner images could be sourced from two places:

--- a/lib/common/helper_functions.sh
+++ b/lib/common/helper_functions.sh
@@ -84,11 +84,6 @@ function usage() {
                              (Optional)
                              By default - aws,gcp
 
-    --version              - Specify Submariner version to be deployed
-                             (Optional)
-                             If not specified, submariner version will be chosen
-                             based of the ACM hub support
-
     --downstream           - Use the flag if downstream images should be used.
                              Submariner images could be sourced from two places:
                                * Official Red Hat ragistry - registry.redhat.io
@@ -233,14 +228,6 @@ function fetch_kubeconfig_contexts_and_pass() {
     done
 }
 
-function validate_given_submariner_version() {
-    INFO "Validate given Submariner version with supported versions"
-    if [[ ! "${SUPPORTED_SUBMARINER_VERSIONS[*]}" =~ $SUBMARINER_VERSION_INSTALL ]]; then
-        ERROR "Suplied Submariner version is not supported. Supported versions - ${SUPPORTED_SUBMARINER_VERSIONS[*]}"
-    fi
-    INFO "Submariner version provided manually - $SUBMARINER_VERSION_INSTALL"
-}
-
 function validate_internal_registry() {
     INFO "Validate proper configuration of cluster internal registry"
     local registry_state
@@ -331,7 +318,6 @@ function print_selected_options() {
         INFO "The following arguments were selected for the execution:
         Run command: $RUN_COMMAND
         Platform: $PLATFORM
-        Specific submariner version: $SUBMARINER_VERSION_INSTALL
         Globalnet: $SUBMARINER_GLOBALNET
         Use downstream deployment: $DOWNSTREAM
         Use downstream mirror: $LOCAL_MIRROR

--- a/lib/common/prerequisites.sh
+++ b/lib/common/prerequisites.sh
@@ -102,7 +102,7 @@ function fetch_submariner_addon_version() {
 function get_subctl_for_testing() {
     INFO "Installing subctl client"
 
-    local image_prefix
+    local image_prefix="$REGISTRY_IMAGE_PREFIX"
     local subctl_version
     local subctl_download_url
     local subctl_archive
@@ -112,11 +112,6 @@ function get_subctl_for_testing() {
     if [[ "$DOWNSTREAM" == "true" ]]; then
         INFO "Download downstream subctl binary for testing"
 
-        if [[ "$subctl_version" == "v0.11"* ]]; then
-            image_prefix="$REGISTRY_IMAGE_PREFIX_TECH_PREVIEW"
-        else
-            image_prefix="$REGISTRY_IMAGE_PREFIX"
-        fi
         subctl_download_url="$VPN_REGISTRY/$REGISTRY_IMAGE_IMPORT_PATH/$image_prefix-subctl-rhel8:$subctl_version"
         INFO "Download subctl from - $subctl_download_url"
 
@@ -124,12 +119,8 @@ function get_subctl_for_testing() {
     else
         INFO "Download upstream subctl binary for testing"
 
-        if [[ "$subctl_version" == "v0.11"*  ]]; then
-            subctl_download_url="$SUBCTL_URL_DOWNLOAD/download/$subctl_version/subctl-$subctl_version-linux-amd64.tar.xz"
-        else
-            WARNING "Due to https://github.com/submariner-io/submariner-operator/issues/1977 devel version will be used"
-            subctl_download_url="$SUBCTL_UPSTREAM_URL/releases/download/subctl-devel/subctl-devel-linux-amd64.tar.xz"
-        fi
+        WARNING "Due to https://github.com/submariner-io/submariner-operator/issues/1977 devel version will be used"
+        subctl_download_url="$SUBCTL_UPSTREAM_URL/releases/download/subctl-devel/subctl-devel-linux-amd64.tar.xz"
         wget -qO- "$subctl_download_url" -O subctl.tar.xz
     fi
 

--- a/lib/submariner_deploy/submariner_deploy.sh
+++ b/lib/submariner_deploy/submariner_deploy.sh
@@ -49,24 +49,14 @@ function prepare_clusters_for_submariner() {
     done
 }
 
-# Starting ACM 2.5.0 and Submariner version 0.12.0
-# a new object has been introdused - Broker.
 function deploy_submariner_broker() {
-    local subm_broker_ver="0.12.0"
-    local version_state
-    version_state=$(validate_version "$subm_broker_ver" "$SUBMARINER_VERSION_INSTALL")
+    INFO "Deploy Submariner broker"
+    INFO "The Globalnet conditiona has been set to - $SUBMARINER_GLOBALNET"
+    local broker_ns="$CLUSTERSET-broker"
 
-    if [[ "$version_state" == "not_valid" ]]; then
-        INFO "The ACM version if lower that 2.5.0. Broker resource will not be created"
-    elif [[ "$version_state" == "valid" ]]; then
-        INFO "Deploy Submariner broker"
-        INFO "The Globalnet conditiona has been set to - $SUBMARINER_GLOBALNET"
-        local broker_ns="$CLUSTERSET-broker"
-
-        NS="$broker_ns" yq eval '.metadata.namespace = env(NS)
-            | .spec.globalnetEnabled = env(SUBMARINER_GLOBALNET)' \
-            "$SCRIPT_DIR/manifests/broker.yaml" | oc apply -f -
-    fi
+    NS="$broker_ns" yq eval '.metadata.namespace = env(NS)
+        | .spec.globalnetEnabled = env(SUBMARINER_GLOBALNET)' \
+        "$SCRIPT_DIR/manifests/broker.yaml" | oc apply -f -
 }
 
 function deploy_submariner_addon() {

--- a/lib/submariner_prepare/downstream_mirroring_workaround.sh
+++ b/lib/submariner_prepare/downstream_mirroring_workaround.sh
@@ -84,15 +84,8 @@ function add_custom_registry_to_node() {
     local ocp_registry_url
     local local_registry_path
     local config_source
-    local submariner_ga="0.12.0"
-    local registry_image_prefix_path
-    version_state=$(validate_version "$submariner_ga" "$SUBMARINER_VERSION_INSTALL")
 
-    if [[ "$version_state" == "valid" ]]; then
-        export registry_image_prefix_path="${REGISTRY_IMAGE_PREFIX}"
-    elif [[ "$version_state" == "not_valid" ]]; then
-        export registry_image_prefix_path="${REGISTRY_IMAGE_PREFIX_TECH_PREVIEW}"
-    fi
+    export registry_image_prefix_path="${REGISTRY_IMAGE_PREFIX}"
 
     for cluster in $MANAGED_CLUSTERS; do
         local ocp_version
@@ -353,27 +346,7 @@ function set_custom_registry_mirror() {
 function import_images_into_local_registry() {
     INFO "Import images into local cluster registry"
     local import_state
-    local submariner_ga="0.12.0"
-    local registry_image_prefix_path
-
-    version_state=$(validate_version "$submariner_ga" "$SUBMARINER_VERSION_INSTALL")
-    if [[ "$version_state" == "valid" ]]; then
-        export registry_image_prefix_path="${REGISTRY_IMAGE_PREFIX}"
-    elif [[ "$version_state" == "not_valid" ]]; then
-        export registry_image_prefix_path="${REGISTRY_IMAGE_PREFIX_TECH_PREVIEW}"
-    fi
-
-    # Starting 0.13.0 the subctl will use a new flow for the nettest image
-    # The subctl will search the image as per the other images repository
-    # It means that starting 0.13.0 we need to import the nettest image into the cluster
-    local subctl_e2e_new_img_flow="0.13.0"
-    local subctl_import_nettest_img="false"
-    local subctl_state
-
-    subctl_state=$(validate_version "$subctl_e2e_new_img_flow" "$SUBMARINER_VERSION_INSTALL")
-    if [[ "$subctl_state" == "valid" ]]; then
-        subctl_import_nettest_img="true"
-    fi
+    local registry_image_prefix_path="${REGISTRY_IMAGE_PREFIX}"
 
     for cluster in $MANAGED_CLUSTERS; do
         local kube_conf="$LOGS/$cluster-kubeconfig.yaml"
@@ -419,21 +392,5 @@ function import_images_into_local_registry() {
             $import_state"
         fi
         INFO "Imported image - $SUBM_IMG_BUNDLE-index:v$SUBMARINER_VERSION_INSTALL"
-
-        if [[ "$subctl_import_nettest_img" == "true" ]]; then
-            # Pulling only the upstream image until downstream image is created
-            # https://github.com/stolostron/backlog/issues/23675
-            INFO "Import nettest used for e2e testing"
-            IMG_NAME="$SUBM_IMG_NETTEST_UPSTREAM" \
-                IMG_NAME_TAG="$SUBM_IMG_NETTEST_PATH_UPSTREAM/$SUBM_IMG_NETTEST_UPSTREAM:$SUBMARINER_VERSION_INSTALL" \
-                TAG="v$SUBMARINER_VERSION_INSTALL" \
-                yq eval '.metadata.name = env(IMG_NAME)
-                | with(.spec.tags[0]; .from.name = env(IMG_NAME_TAG)
-                | .name = env(TAG))' \
-                "$SCRIPT_DIR/manifests/image-stream.yaml" \
-                | KUBECONFIG="$kube_conf" oc apply -f -
-
-                INFO "Imported image - $SUBM_IMG_NETTEST_PATH_UPSTREAM/$SUBM_IMG_NETTEST_UPSTREAM:$SUBMARINER_VERSION_INSTALL"
-        fi
     done
 }

--- a/run.sh
+++ b/run.sh
@@ -83,23 +83,12 @@ function prepare() {
 }
 
 function deploy_submariner() {
-    if [[ -n "$SUBMARINER_VERSION_INSTALL" ]]; then
-        validate_given_submariner_version
-    else
-        select_submariner_version_and_channel_to_deploy
-    fi
+    select_submariner_version_and_channel_to_deploy
 
     if [[ "$PLATFORM" =~ "azure" ]]; then
-        # Starting from submariner 0.13.0, cloud prepare
-        # is done automatically.
-        # Only older versions require manual steps.
-        local azure_cloud_support="0.13.0"
-        version_state=$(validate_version "$azure_cloud_support" "$SUBMARINER_VERSION_INSTALL")
-        if [[ "$version_state" == "not_valid" ]]; then
-            INFO "Perform manual cloud prepare for Azure"
-            verify_az_cli
-            prepare_azure_cloud
-        fi
+        INFO "Perform manual cloud prepare for Azure"
+        verify_az_cli
+        prepare_azure_cloud
     fi
 
     if [[ "$DOWNSTREAM" == 'true' ]]; then

--- a/variables
+++ b/variables
@@ -28,12 +28,6 @@ export VALIDATION_STATE=""
 # The value will define the version of Submariner and a channel
 
 # Declare associative arrays for acm/submariner versions
-declare -A ACM_2_4=(
-    [acm_version]='2.4'
-    [submariner_version]='0.11.2'
-    [channel]='alpha'
-)
-export ACM_2_4
 declare -A ACM_2_5=(
     [acm_version]='2.5'
     [submariner_version]='0.12.1'
@@ -70,30 +64,6 @@ declare -A ACM_2_5_6=(
     [channel]='stable'
 )
 export ACM_2_5_6
-declare -A ACM_2_6=(
-    [acm_version]='2.6'
-    [submariner_version]='0.13.0'
-    [channel]='stable'
-)
-export ACM_2_6
-declare -A ACM_2_6_2=(
-    [acm_version]='2.6.2'
-    [submariner_version]='0.13.1'
-    [channel]='stable'
-)
-export ACM_2_6_2
-declare -A ACM_2_6_3=(
-    [acm_version]='2.6.3'
-    [submariner_version]='0.13.1'
-    [channel]='stable'
-)
-export ACM_2_6_3
-declare -A ACM_2_7=(
-    [acm_version]='2.7'
-    [submariner_version]='0.14.0'
-    [channel]='stable'
-)
-export ACM_2_7
 # Declare array of COMPONENTS_VERSIONS of associative arrays
 export COMPONENT_VERSIONS=("${!ACM@}")
 
@@ -111,7 +81,6 @@ export LOCAL_MIRROR="true"
 # if the source of the images will be set to quay (downstream).
 # The submariner version will be selected automatically.
 export SUBMARINER_VERSION_INSTALL=""
-export SUPPORTED_SUBMARINER_VERSIONS=("0.11.0" "0.11.2" "0.12.1" "0.12.2" "0.13.0")
 export SUBMARINER_CHANNEL_RELEASE=""
 # The default IPSEC NATT port is - 4500
 export SUBMARINER_IPSEC_NATT_PORT=4505
@@ -127,7 +96,6 @@ export STAGING_REGISTRY="registry.stage.redhat.io"
 # External RedHat downstream registry (require authentication)
 export BREW_REGISTRY="brew.registry.redhat.io"
 export REGISTRY_IMAGE_PREFIX="rhacm2"
-export REGISTRY_IMAGE_PREFIX_TECH_PREVIEW="rhacm2-tech-preview"
 export REGISTRY_IMAGE_IMPORT_PATH="rh-osbs"
 export CATALOG_REGISTRY="registry.access.redhat.com"
 export CATALOG_IMAGE_PREFIX="openshift4"


### PR DESCRIPTION
- The ACM 2.5.6 / Submariner 0.12.3 version should contains the flow related to that version only. Remove other versions dependencies.
- Remove manual selection of submariner version. Submariner version tied to ACM version.