### PR TITLE
Integrate Cypress into the test pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,14 @@ export OC_CLUSTER_PASS=<password of the cluster user>
                              (Optional)
                              By default - false
 
+    Tests arguments:
+    ----------------
+    --test-type            - Select test type that should be executed.
+                             - e2e (api based testing)
+                             - ui (cypress testing)
+                             (Optional)
+                             By default - e2e,ui
+
     Submariner configuration arguments:
     -----------------------------------
     --globalnet            - Set the state of the Globalnet for the Submariner deployment.

--- a/cypress/package.json
+++ b/cypress/package.json
@@ -20,17 +20,16 @@
     "url": "https://github.com/stolostron/acmqe-mcn-test/issues"
   },
   "homepage": "https://github.com/stolostron/acmqe-mcn-test#readme",
-  "dependencies": {},
   "devDependencies": {
-    "cypress": "^10.7.0",
     "@types/cypress": "^1.1.3",
+    "cypress": "^10.7.0",
     "cypress-fill-command": "^1.0.2",
     "cypress-grep": "^2.11.0",
     "cypress-localstorage-commands": "^2.2.1",
     "cypress-multi-reporters": "^1.4.0",
     "cypress-terminal-report": "^2.0.0",
     "cypress-wait-until": "^1.7.1",
-    "junit-report-merger": "^3.0.1",
+    "junit-report-merger": "^4.0.0",
     "mocha": "^9.1.3",
     "mocha-junit-reporter": "^2.0.2"
   }

--- a/lib/common/helper_functions.sh
+++ b/lib/common/helper_functions.sh
@@ -105,6 +105,14 @@ function usage() {
                              (Optional)
                              By default - false
 
+    Tests arguments:
+    ----------------
+    --test-type            - Select test type that should be executed.
+                             - e2e (api based testing)
+                             - ui (cypress testing)
+                             (Optional)
+                             By default - e2e,ui
+
     Submariner configuration arguments:
     -----------------------------------
     --globalnet            - Set the state of the Globalnet for the Submariner deployment.

--- a/lib/common/prerequisites.sh
+++ b/lib/common/prerequisites.sh
@@ -136,3 +136,18 @@ function verify_subctl_command() {
         INFO "The subctl client exists and has the required version - $subctl_client"
     fi
 }
+
+# Verify system readiness for cypress testing.
+# Since cypress requirements like npm and nodejs requires
+# system administration priviliges, prerequisites will not be installed.
+# The function only report readiness state.
+function verify_cypress() {
+    INFO "Verify cypress readiness"
+
+    if ! command -v npm &> /dev/null || ! command -v node &> /dev/null; then
+        INFO "Cypress prerequisites are not ready"
+        export UI_TESTS="false"
+    else
+        INFO "Cypress requirements fulfilled"
+    fi
+}

--- a/lib/submariner_test/submariner_e2e.sh
+++ b/lib/submariner_test/submariner_e2e.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# The function executes Submariner E2E tests by using the subctl tool.
+# The subctl tool is able to run E2E tests only on two clusters
+# at the same time.
+# In order to be able to test all clusters which contains
+# submariner addon, the function below is using the first managed
+# cluster as a primary cluster and all other clusters will run E2E
+# tests with the primary cluster.
+function execute_submariner_e2e_tests() {
+    INFO "Execute Submariner E2E tests"
+
+    # Subctl E2E tests are working with 2 clusters only at a time
+    local primary_test_cluster
+    local secondary_test_cluster
+    local tests_basename
+
+    primary_test_cluster=$(echo "$MANAGED_CLUSTERS" | head -n 1)
+
+    for cluster in $MANAGED_CLUSTERS; do
+        if [[ "$cluster" == "$primary_test_cluster" ]]; then
+            continue
+        fi
+
+        secondary_test_cluster="$cluster"
+        tests_basename=$(combine_tests_basename "e2e" "$primary_test_cluster" "$secondary_test_cluster")
+
+        INFO "Running tests between $primary_test_cluster and $secondary_test_cluster clusters"
+        export KUBECONFIG="$LOGS/$primary_test_cluster-kubeconfig.yaml:$LOGS/$secondary_test_cluster-kubeconfig.yaml"
+
+        INFO "Show all Submariner information"
+        subctl show all 2>&1 \
+            | tee  "$TESTS_LOGS/${tests_basename}_subctl_show_all.log" \
+            || add_test_error $?
+
+        INFO "Execute diagnose all tests"
+        subctl diagnose all --verbose \
+            --context "$primary_test_cluster" \
+            --context "$secondary_test_cluster" 2>&1 \
+            | tee "$TESTS_LOGS/${tests_basename}_subctl_diagnose_all.log" \
+            || add_test_error $?
+
+        INFO "Execute diagnose firewall inter-cluster tests"
+        subctl diagnose firewall inter-cluster --verbose \
+            --context "$primary_test_cluster" \
+            --remotecontext "$secondary_test_cluster" 2>&1 \
+            |  tee "$TESTS_LOGS/${tests_basename}_subctl_firewall_tests.log" \
+            || add_test_error $?
+
+        INFO "Execute E2E tests"
+        subctl verify --only service-discovery,connectivity --verbose \
+            --junit-report "$TESTS_LOGS/${tests_basename}_e2e_junit.xml" \
+            --context "$primary_test_cluster" \
+            --tocontext "$secondary_test_cluster" 2>&1 \
+            | tee "$TESTS_LOGS/${tests_basename}_subctl_e2e_tests.log" \
+            || add_test_error $?
+        unset KUBECONFIG
+    done
+    INFO "The E2E tests execution finished"
+}

--- a/lib/submariner_test/submariner_test.sh
+++ b/lib/submariner_test/submariner_test.sh
@@ -1,73 +1,47 @@
 #!/bin/bash
 
-# Perform Submariner test by using the "subctl" command.
+# Perform Submariner E2E tests by using the "subctl" command
+# and Submariner UI tests by using cypress tool.
 
-# The function executes Submariner E2E tests by using the subctl tool.
-# The subctl tool is able to run E2E tests only on two clusters
-# at the same time.
-# In order to be able to test all clusters which contains
-# submariner addon, the function below is using the first managed
-# cluster as a primary cluster and all other clusters will run E2E
-# tests with the primary cluster.
 function execute_submariner_tests() {
     INFO "Execute Submariner tests"
 
     rm -rf "$TESTS_LOGS"
     mkdir -p "$TESTS_LOGS"
 
-    # Subctl E2E tests are working with 2 clusters only at a time
-    local primary_test_cluster
-    local secondary_test_cluster
-    local tests_basename
+    verify_subctl_command
 
-    primary_test_cluster=$(echo "$MANAGED_CLUSTERS" | head -n 1)
+    if [[ "$TEST_TYPE" =~ "e2e" ]]; then
+        execute_submariner_e2e_tests
+    fi
 
-    for cluster in $MANAGED_CLUSTERS; do
-        if [[ "$cluster" == "$primary_test_cluster" ]]; then
-            continue
+    if [[ "$TEST_TYPE" =~ "ui" ]]; then
+        verify_cypress
+        # If cypress prerequisites are not fulfilled,
+        # cypress tests will be skipped.
+        if [[ "$UI_TESTS" == "false" ]]; then
+            WARNING "Skip UI tests execution - system is not ready"
+        else
+            execute_submariner_ui_tests
         fi
+    fi
 
-        secondary_test_cluster="$cluster"
-        tests_basename=$(combine_tests_basename "$primary_test_cluster" "$secondary_test_cluster")
-
-        INFO "Running tests between $primary_test_cluster and $secondary_test_cluster clusters"
-        export KUBECONFIG="$LOGS/$primary_test_cluster-kubeconfig.yaml:$LOGS/$secondary_test_cluster-kubeconfig.yaml"
-
-        INFO "Show all Submariner information"
-        subctl show all 2>&1 \
-            | tee  "$TESTS_LOGS/${tests_basename}_subctl_show_all.log" \
-            || add_test_error $?
-
-        INFO "Execute diagnose all tests"
-        subctl diagnose all --verbose \
-            --context "$primary_test_cluster" \
-            --context "$secondary_test_cluster" 2>&1 \
-            | tee "$TESTS_LOGS/${tests_basename}_subctl_diagnose_all.log" \
-            || add_test_error $?
-
-        INFO "Execute diagnose firewall inter-cluster tests"
-        subctl diagnose firewall inter-cluster --verbose \
-            --context "$primary_test_cluster" \
-            --remotecontext "$secondary_test_cluster" 2>&1 \
-            |  tee "$TESTS_LOGS/${tests_basename}_subctl_firewall_tests.log" \
-            || add_test_error $?
-
-        INFO "Execute E2E tests"
-        subctl verify --only service-discovery,connectivity --verbose \
-            --junit-report "$TESTS_LOGS/${tests_basename}_e2e_junit.xml" \
-            --context "$primary_test_cluster" \
-            --tocontext "$secondary_test_cluster" 2>&1 \
-            | tee "$TESTS_LOGS/${tests_basename}_subctl_e2e_tests.log" \
-            || add_test_error $?
-        unset KUBECONFIG
-    done
     INFO "Tests execution finished"
     INFO "All the logs are placed within the $TESTS_LOGS directory"
 }
 
+# The function will combine test report basename.
+# The function has types of tests it serves - "e2e" and "ui".
+# The e2e test basename will contain platforms in the basename:
+# - ACM-2.7.0-Submariner-0.14.1-AWS-GCP-Globalnet
+# It means need to provide all three args - "type", "primary_cluster", "second_cluster"
+# While UI test will skip platform details as it run only for the dashboard UI
+# - ACM-2.7.0-Submariner-0.14.1-Globalnet-UI
+# It means need to provide two args - "type" and "primary_cluster".
 function combine_tests_basename() {
-    local primary_cluster="$1"
-    local secondary_cluster="$2"
+    local type="$1"  # e2e or ui
+    local primary_cluster="$2"
+    local secondary_cluster="$3"
     local acm_ver
     local subm_ver
     local primary_cl_platform
@@ -80,8 +54,6 @@ function combine_tests_basename() {
         oc -n submariner-operator get subs submariner \
         -o jsonpath='{.status.currentCSV}' \
         | grep -Po '(?<=submariner.v)[^)]*' | cut -d '-' -f1)
-    primary_cl_platform=$(locate_cluster_platform "$primary_cluster")
-    secondary_cl_platform=$(locate_cluster_platform "$secondary_cluster")
 
     globalnet_state=$(KUBECONFIG="$LOGS/$primary_cluster-kubeconfig.yaml" \
         oc -n submariner-operator get pods -l=app=submariner-globalnet \
@@ -92,7 +64,14 @@ function combine_tests_basename() {
         globalnet="Globalnet"
     fi
 
-    echo "ACM-${acm_ver}-Submariner-${subm_ver}-${primary_cl_platform}-${secondary_cl_platform}-${globalnet}"
+    if [[ "$type" == "e2e" ]]; then
+        primary_cl_platform=$(locate_cluster_platform "$primary_cluster")
+        secondary_cl_platform=$(locate_cluster_platform "$secondary_cluster")
+
+        echo "ACM-${acm_ver}-Submariner-${subm_ver}-${primary_cl_platform}-${secondary_cl_platform}-${globalnet}"
+    elif [[ "$type" == "ui" ]]; then
+        echo "ACM-${acm_ver}-Submariner-${subm_ver}-${globalnet}-UI"
+    fi
 }
 
 # When one of the tests fails, add the error note to a global variable.

--- a/lib/submariner_test/submariner_ui.sh
+++ b/lib/submariner_test/submariner_ui.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# The function executes Submariner UI tests by using cypress tool.
+# The cypress tests located within the current repository.
+function execute_submariner_ui_tests() {
+    INFO "Execute Submariner UI tests"
+
+    pushd "$SCRIPT_DIR/cypress/" || return
+    prepare_cypress_env
+
+    local base_url
+    base_url=$(oc whoami --show-console)
+    export CYPRESS_BASE_URL="$base_url"
+    export CYPRESS_OPTIONS_HUB_USER="$OC_CLUSTER_USER"
+    export CYPRESS_OPTIONS_HUB_PASSWORD="$OC_CLUSTER_PASS"
+
+    npx cypress run --browser chrome --headless
+    combine_cypress_reports
+
+    popd || return
+}
+
+function prepare_cypress_env() {
+    rm -rf "$SCRIPT_DIR/cypress/results/"
+
+    npm config set unsafe-perm true
+    npm install
+    npm ci
+    npm_config_yes=true npx browserslist@latest --update-db
+}
+
+function combine_cypress_reports() {
+    INFO "Combine cypress reports"
+
+    local primary_cluster
+    primary_cluster=$(echo "$MANAGED_CLUSTERS" | head -n 1)
+    tests_basename=$(combine_tests_basename "ui" "$primary_cluster")
+
+    npx jrm "$TESTS_LOGS/${tests_basename}_junit.xml" results/test-results-*.xml
+}

--- a/run.sh
+++ b/run.sh
@@ -29,6 +29,10 @@ source "${SCRIPT_DIR}/lib/submariner_deploy/submariner_deploy.sh"
 # shellcheck disable=SC1091
 source "${SCRIPT_DIR}/lib/submariner_test/submariner_test.sh"
 # shellcheck disable=SC1091
+source "${SCRIPT_DIR}/lib/submariner_test/submariner_e2e.sh"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/lib/submariner_test/submariner_ui.sh"
+# shellcheck disable=SC1091
 source "${SCRIPT_DIR}/lib/reporting/polarion.sh"
 
 
@@ -116,7 +120,6 @@ function deploy_submariner() {
 }
 
 function test_submariner() {
-    verify_subctl_command
     execute_submariner_tests
 
     if [[ "$SKIP_GATHER_LOGS" == "false" ]]; then
@@ -202,6 +205,12 @@ function parse_arguments() {
             --skip-gather-logs)
                 if [[ -n "$2" ]]; then
                     export SKIP_GATHER_LOGS="$2"
+                    shift 2
+                fi
+                ;;
+            --test-type)
+                if [[ -n "$2" ]]; then
+                    export TEST_TYPE="$2"
                     shift 2
                 fi
                 ;;

--- a/variables
+++ b/variables
@@ -89,3 +89,9 @@ export POLARION_VARS_FILE=""
 export POLARION_ADD_SKIPPED="false"
 
 export LATEST_IIB=""
+
+# Test type that should be executed.
+# e2e (api testing), ui (cypress testing)
+export TEST_TYPE="e2e,ui"
+# Execute or skip UI tests. By default, execute.
+export UI_TESTS="true"


### PR DESCRIPTION
- Add cypress tests execution into the pipeline

- Split e2e and ui testing into different files. Both are called from the same "execute_submariner_tests" function.

- Cypress requires "npm" and "nodejs" installed as prerequisites. Since those packages requires admin privileges and can't be installed during ci pipeline execution, the pipeline will check the state of the environment for those packages. If package will be missing, cypress execution will be skipped.

- Add a new flag for testing execution - "--test-type". The flag controls execution of tests - e2e (api) and ui (cypress). By default, both testing methods will be mentioned, but a user count change it if needed.

- Refactor "combine_tests_basename" function to generate tests basenames for both e2e and ui testing.