### PR TITLE
[release-2.6] Cypress - fix clusterset api version

### DIFF
--- a/cypress/cypress/apis/clusterSet.js
+++ b/cypress/cypress/apis/clusterSet.js
@@ -22,7 +22,7 @@ export const getClusterSet = (clusterSet) => {
         method: "GET",
         url:
             constants.apiUrl +
-            constants.ocm_cluster_api_v1beta2_path +
+            constants.ocm_cluster_api_v1beta1_path +
             constants.managedclustersets_path +
             '/' + clusterSet,
         headers: headers,


### PR DESCRIPTION
In the versions below acm 2.7.0, cluster set is using api version "/apis/cluster.open-cluster-management.io/v1beta1". In the newer version of acm 2.7.0, the version has been increased to "/apis/cluster.open-cluster-management.io/v1beta2".

Update the "release-2.6" branch to use the relevant api version.