### PR TITLE
Remove fixed subctl image workaround

### DIFF
--- a/lib/submariner_prepare/downstream_mirroring_workaround.sh
+++ b/lib/submariner_prepare/downstream_mirroring_workaround.sh
@@ -393,11 +393,6 @@ function import_images_into_local_registry() {
             $import_state"
         fi
 
-        INFO "Apply workaround for https://issues.redhat.com/browse/ACM-2387"
-        KUBECONFIG="$kube_conf" oc -n openshift tag \
-            "$SUBM_IMG_NETTEST_DOWNSTREAM:v$SUBMARINER_VERSION_INSTALL" \
-            "$SUBM_IMG_NETTEST_DOWNSTREAM:$SUBMARINER_VERSION_INSTALL"
-
         INFO "Imported image - $SUBM_IMG_BUNDLE-index:v$SUBMARINER_VERSION_INSTALL"
     done
 }


### PR DESCRIPTION
The image tag bug has been fixed.
Removing the workaround.
Reference - https://issues.redhat.com/browse/ACM-2387