### PR TITLE
Rename cypress tests

### DIFF
--- a/cypress/cypress/e2e/01_submariner_deployment_validation.cy.js
+++ b/cypress/cypress/e2e/01_submariner_deployment_validation.cy.js
@@ -5,7 +5,7 @@
 
 /// <reference types="cypress" />
 
-import { submarinerClusterSetMethods } from '../../views/submariner/actions/submariner_actions'
+import { submarinerClusterSetMethods } from '../views/submariner/actions/submariner_actions'
 
 describe('submariner - Deployment validation', {
     tags: ['@submariner', '@e2e'],

--- a/cypress/cypress/e2e/02_submariner_uninstall.cy.js
+++ b/cypress/cypress/e2e/02_submariner_uninstall.cy.js
@@ -38,7 +38,14 @@ describe('submariner - uninstall validation', {
                 cy.get('.pf-c-dropdown__menu-item').should('be.visible').click()
                 cy.get('.pf-c-form__actions > .pf-m-primary').click()
 
-                cy.get('[data-label="Cluster"]', {timeout: 210000}).should('not.exist')
+                // Submariner uninstall process requires deletion of resource on the cloud,
+                // where the actual resources exist.
+                // Resource deletion may take time and from the UI testing we are unable to
+                // fetch the deletion state.
+                // Some of the clouds may take more time to delete the resource.
+                // Set the final timeout to 5 minutes.
+                // If the resources still exist after the timeout, fail the test.
+                cy.get('[data-label="Cluster"]', {timeout: 300000}).should('not.exist')
             }
         })
     }) 


### PR DESCRIPTION
- Rename cypress test to create an order convention. The tests will be executed base on the numbering convention.

- Increase the uninstall test timeout to 5 minutes. This timeout currently suited by the following tested platforms: aws, gcp and azure.