### PR TITLE
Update clusterset manifest api version

### DIFF
--- a/manifests/cluster-set.yaml
+++ b/manifests/cluster-set.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.open-cluster-management.io/v1beta1
+apiVersion: cluster.open-cluster-management.io/v1beta2
 kind: ManagedClusterSet
 metadata:
   name: "submariner"


### PR DESCRIPTION
In acm 2.7 the api version for the clusterset has been updated from: cluster.open-cluster-management.io/v1beta1
to
cluster.open-cluster-management.io/v1beta2

Update hte manifest file.