### PR TITLE
Prevent pipeline failure because of cypress test fail

### DIFF
--- a/lib/submariner_test/submariner_ui.sh
+++ b/lib/submariner_test/submariner_ui.sh
@@ -19,7 +19,7 @@ function execute_submariner_ui_tests() {
     export CYPRESS_OPTIONS_HUB_USER="$OC_CLUSTER_USER"
     export CYPRESS_OPTIONS_HUB_PASSWORD="$OC_CLUSTER_PASS"
 
-    npx cypress run --browser chrome --headless --env grepFilterSpecs=true,grepTags=@e2e
+    npx cypress run --browser chrome --headless --env grepFilterSpecs=true,grepTags=@e2e || true
 
     INFO "Combine cypress reports"
     npx jrm "$TESTS_LOGS/${tests_basename}_junit.xml" results/test-results-*.xml


### PR DESCRIPTION
During execution of cypress tests, if one of the tests fails, the command exit with non zero exist code.
Prevent this failure to provide the ability to gather logs for deployment.