### PR TITLE
Remove Azure platform from default execution

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
         string(name: 'OC_CLUSTER_USER', defaultValue: '', description: 'ACM Hub username')
         string(name: 'OC_CLUSTER_PASS', defaultValue: '', description: 'ACM Hub password')
         extendedChoice(name: 'PLATFORM', description: 'The managed clusters platform that should be tested',
-            value: 'aws,gcp,azure,vsphere', defaultValue: 'aws,gcp,azure,vsphere', multiSelectDelimiter: ',', type: 'PT_CHECKBOX')
+            value: 'aws,gcp,azure,vsphere', defaultValue: 'aws,gcp,vsphere', multiSelectDelimiter: ',', type: 'PT_CHECKBOX')
         booleanParam(name: 'GLOBALNET', defaultValue: true, description: 'Deploy Globalnet on Submariner')
         string(name: 'VERSION', defaultValue: '', description: 'Define specific version of Submariner to be installed')
         booleanParam(name: 'DOWNSTREAM', defaultValue: true, description: 'Deploy downstream version of Submariner')


### PR DESCRIPTION
Due to a bug with cluster length in Azure platform [1] [2], remove the default execution of Azure platform from the Jenkins pipeline. Re-add once the bug is fixed.

[1] - https://bugzilla.redhat.com/show_bug.cgi?id=2118385 
[2] - https://issues.redhat.com/browse/ACM-2076