### PR TITLE
Switch to digest deployment flow

### DIFF
--- a/lib/common/prerequisites.sh
+++ b/lib/common/prerequisites.sh
@@ -76,7 +76,7 @@ function fetch_submariner_addon_version() {
 function get_subctl_for_testing() {
     INFO "Installing subctl client"
 
-    local image_prefix="$REGISTRY_IMAGE_PREFIX"
+    # local image_prefix="$REGISTRY_IMAGE_PREFIX"
     local subctl_version
     local subctl_download_url
     local subctl_archive
@@ -84,12 +84,19 @@ function get_subctl_for_testing() {
     subctl_version=$(fetch_submariner_addon_version | cut -d '-' -f1)
 
     if [[ "$DOWNSTREAM" == "true" ]]; then
-        INFO "Download downstream subctl binary for testing"
+        # INFO "Download downstream subctl binary for testing"
+        # subctl_download_url="$VPN_REGISTRY/$REGISTRY_IMAGE_IMPORT_PATH/$image_prefix-subctl-rhel8:$subctl_version"
+        # INFO "Download subctl from - $subctl_download_url"
+        # oc image extract --insecure=true "$subctl_download_url" --path=/dist/subctl-*-linux-amd64.tar.xz:./ --confirm
 
-        subctl_download_url="$VPN_REGISTRY/$REGISTRY_IMAGE_IMPORT_PATH/$image_prefix-subctl-rhel8:$subctl_version"
+        # Untill the https://github.com/submariner-io/subctl/pull/526 patch will be available downstream,
+        # use upstream subctl binary
+
+        INFO "Download subctl binary for testing"
+        subctl_version="${subctl_version:1:4}"
+        subctl_download_url="$SUBCTL_UPSTREAM_URL/releases/download/subctl-release-$subctl_version/subctl-release-$subctl_version-linux-amd64.tar.xz"
         INFO "Download subctl from - $subctl_download_url"
-
-        oc image extract --insecure=true "$subctl_download_url" --path=/dist/subctl-*-linux-amd64.tar.xz:./ --confirm
+        wget -qO- "$subctl_download_url" -O subctl.tar.xz
     else
         INFO "Download upstream subctl binary for testing"
 

--- a/run.sh
+++ b/run.sh
@@ -103,7 +103,6 @@ function deploy_submariner() {
         fi
 
         if [[ "$LOCAL_MIRROR" == 'false' ]]; then
-            # https://issues.redhat.com/browse/RFE-1608
             create_icsp
         fi
 

--- a/variables
+++ b/variables
@@ -46,7 +46,7 @@ export COMPONENT_VERSIONS=("${!ACM@}")
 export DOWNSTREAM="false"
 # Due to https://issues.redhat.com/browse/RFE-1608, add the ability
 # to use local ocp cluster registry and import the images.
-export LOCAL_MIRROR="true"
+export LOCAL_MIRROR="false"
 # The submariner version will be defined and used
 # if the source of the images will be set to quay (downstream).
 # The submariner version will be selected automatically.


### PR DESCRIPTION
Submariner deployment started to support references to images by digest instead of floating tags.
It allows to:
- Perform deployment and testing of ROSA platform
- Reduce deployment time by 20-25 minutes

Remove configuration of MachineSet and use instead ImageContentSourcePolaicy object creation.
Remove import of the images into internal cluster registry. The images will be fetched directly from the mirror registry.

Add "--image-override" argument to subctl binary to specify nettest image with digest reference.