### PR TITLE
Fix polarion_report script call

### DIFF
--- a/lib/reporting/polarion.sh
+++ b/lib/reporting/polarion.sh
@@ -7,12 +7,12 @@ function report_polarion() {
     INFO "Polarion: Report Polarion test state (internal only)"
     local venv="/tmp/subm"
 
-    python -m venv "$venv"
+    python3 -m venv "$venv"
     # shellcheck source=/dev/null
     source "$venv/bin/activate"
     pip install -r requirements.txt
 
     INFO "PolarionL Process reports"
-    python lib/reporting/polarion_report.py \
+    python3 lib/reporting/polarion_report.py \
         --config "$POLARION_VARS_FILE" --path "$TESTS_LOGS"
 }

--- a/lib/reporting/polarion_report.py
+++ b/lib/reporting/polarion_report.py
@@ -347,8 +347,8 @@ class PolarionPushReports:
         # Generation of the report may take time.
         # Retry a number of times to fetch the report.
         timeout = 0
-        max_timeout = 5
-        wait_time = 5
+        max_timeout = 10
+        wait_time = 10
         while timeout < max_timeout:
             try:
                 requests.packages.urllib3.disable_warnings()


### PR DESCRIPTION
Polarion report script should be called with "python3" instead of "python", otherwise it's failed.