### PR TITLE
Remove "startingCSV" parameter from Submariner subscription

### DIFF
--- a/lib/submariner_deploy/submariner_deploy.sh
+++ b/lib/submariner_deploy/submariner_deploy.sh
@@ -8,12 +8,10 @@ function prepare_clusters_for_submariner() {
     INFO "Perform Submariner cloud prepare for the managed clusters"
     local creds
     local submariner_channel
-    local submariner_version
     local catalog_ns="openshift-marketplace"
     local catalog_source="redhat-operators"
 
     submariner_channel="$SUBMARINER_CHANNEL_RELEASE-$(echo "$SUBMARINER_VERSION_INSTALL" | grep -Po '.*(?=\.)')"
-    submariner_version="submariner.v$SUBMARINER_VERSION_INSTALL"
 
     if [[ "$DOWNSTREAM" == 'true' ]]; then
         catalog_source="submariner-catalog"
@@ -39,9 +37,7 @@ function prepare_clusters_for_submariner() {
         INFO "Use $SUBMARINER_GATEWAY_COUNT gateway node for $cluster cluster"
 
         CL="$cluster" CRED="$creds" SUBM_CHAN="$submariner_channel" \
-            SUBM_VER="$submariner_version" NS="$catalog_ns" \
-            SUBM_SOURCE="$catalog_source" \
-            LB="$load_balancer" \
+            NS="$catalog_ns" SUBM_SOURCE="$catalog_source" LB="$load_balancer" \
             yq eval '.metadata.namespace = env(CL)
             | .spec.credentialsSecret.name = env(CRED)
             | .spec.IPSecNATTPort = env(SUBMARINER_IPSEC_NATT_PORT)
@@ -50,8 +46,7 @@ function prepare_clusters_for_submariner() {
             | .spec.gatewayConfig.gateways = env(SUBMARINER_GATEWAY_COUNT)
             | .spec.subscriptionConfig.channel = env(SUBM_CHAN)
             | .spec.subscriptionConfig.source = env(SUBM_SOURCE)
-            | .spec.subscriptionConfig.sourceNamespace = env(NS)
-            | .spec.subscriptionConfig.startingCSV = env(SUBM_VER)' \
+            | .spec.subscriptionConfig.sourceNamespace = env(NS)' \
             "$SCRIPT_DIR/manifests/submariner-config.yaml" | oc apply -f -
 
         if [[ "$SUBMARINER_GATEWAY_RANDOM" == "true" ]]; then

--- a/manifests/submariner-config.yaml
+++ b/manifests/submariner-config.yaml
@@ -17,4 +17,3 @@ spec:
     channel: $SUBMARINER_CHANNEL
     source: $SUBMARINER_SOURCE
     sourceNamespace: openshift-marketplace
-    startingCSV: $SUBMARINER_VERSION


### PR DESCRIPTION
The "startingCSV" parameter from Subscription section under SubmarinerConfig should not be used.
The Submariner install version will be set automatically to latest z version of the minur varsion based on the defined channel.