### PR TITLE
Update Jenkinsfile image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,9 @@
 pipeline {
     agent {
         docker {
-            image 'quay.io/generic/rhel8'
+            image 'quay.io/stolostron/acm-qe:submariner-fedora36-nodejs18'
+            registryUrl 'https://quay.io/stolostron/acm-qe'
+            registryCredentialsId '0089f10c-7a3a-4d16-b5b0-3a2c9abedaa2'
             args '--network host -u 0:0'
         }
     }


### PR DESCRIPTION
Update Jenkinsfile to use a dedicated Submariner image by jenkins pipeline.
The Dockerfile could be seen in the root of the repository as well.