### PR TITLE
Remove "become root" from docker image in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ pipeline {
             image 'quay.io/stolostron/acm-qe:submariner-fedora36-nodejs18'
             registryUrl 'https://quay.io/stolostron/acm-qe'
             registryCredentialsId '0089f10c-7a3a-4d16-b5b0-3a2c9abedaa2'
-            args '--network host -u 0:0'
+            args '--network host'
         }
     }
     options {


### PR DESCRIPTION
Docker image has the following configuration within Jenkins file: "args '--network host -u 0:0'"

The "-u 0:0" sets the container to run as root.
It created the following error during cypress execution:

================
npm ERR! code 1
npm ERR! path /home/centos/workspace/qe-acm-automation-poc/submariner_e2e_tests/cypress/node_modules/cypress npm ERR! command failed
npm ERR! command sh -c node index.js --exec install npm ERR! Cypress cannot write to the cache directory due to file permissions npm ERR!
npm ERR! See discussion and possible solutions at
npm ERR! https://github.com/cypress-io/cypress/issues/1281 npm ERR!
npm ERR! ----------
npm ERR!
npm ERR! Failed to access /root/.cache/Cypress:
npm ERR!
npm ERR! EACCES: permission denied, mkdir '/root/.cache/Cypress'
 ================

Remove this argument to run as regular user.