### PR TITLE
Add disruptive tests to e2e execution

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,6 +19,7 @@ pipeline {
             value: 'aws,gcp,azure,vsphere', defaultValue: 'aws,gcp,vsphere', multiSelectDelimiter: ',', type: 'PT_CHECKBOX')
         booleanParam(name: 'GLOBALNET', defaultValue: true, description: 'Deploy Globalnet on Submariner')
         booleanParam(name: 'DOWNSTREAM', defaultValue: true, description: 'Deploy downstream version of Submariner')
+        booleanParam(name: 'SUBMARINER_GATEWAY_RANDOM', defaultValue: true, description: 'Deploy two submariner gateways on one of the clusters')
         string(name:'TEST_TAGS', defaultValue: '', description: 'A tag to control job execution')
         booleanParam(name: 'POLARION', defaultValue: true, description: 'Publish tests results to Polarion')
     }
@@ -108,6 +109,13 @@ pipeline {
                         DOWNSTREAM = "--downstream true"
                     }
 
+                    // Deploy two submariner gateways on one of the clusters
+                    // to test submariner gateway fail-over scenario.
+                    SUBMARINER_GATEWAY_RANDOM = "--subm-gateway-random false"
+                    if (params.SUBMARINER_GATEWAY_RANDOM) {
+                        SUBMARINER_GATEWAY_RANDOM = "--subm-gateway-random true"
+                    }
+
                     // The '@post-release' tag meant to test post GA release
                     // thus don't use the downstream tag.
                     // Override the any state of the DOWNSTREAM param.
@@ -117,7 +125,7 @@ pipeline {
                 }
 
                 sh """
-                ./run.sh --deploy --platform "${params.PLATFORM}" $GLOBALNET $DOWNSTREAM
+                ./run.sh --deploy --platform "${params.PLATFORM}" $GLOBALNET $DOWNSTREAM $SUBMARINER_GATEWAY_RANDOM
                 """
             }
         }

--- a/lib/submariner_test/submariner_e2e.sh
+++ b/lib/submariner_test/submariner_e2e.sh
@@ -77,7 +77,9 @@ function execute_submariner_e2e_tests() {
             || add_test_error $?
 
         INFO "Execute E2E tests"
-        subctl verify --only service-discovery,connectivity --verbose \
+        subctl verify --verbose \
+            --only service-discovery,connectivity,gateway-failover \
+            --disruptive-tests \
             --image-override submariner-nettest="$nettest_img_ref" \
             --junit-report "$TESTS_LOGS/${tests_basename}_e2e_junit.xml" \
             --context "$primary_test_cluster" \


### PR DESCRIPTION
Add disruptive tests to e2e execution and perform deployment of two submariner gateways on one of the clusters to test fail-over scenario.