### PR TITLE
Fix Cypress "submariner_addon" test failure

### DIFF
--- a/cypress/cypress/e2e/04_submariner_addon.cy.js
+++ b/cypress/cypress/e2e/04_submariner_addon.cy.js
@@ -23,9 +23,8 @@ describe('submariner - validate submariner addon tab', {
     it('test the Submariner add-ons', { tags: ['addon'] }, function () {
         let clusterSetName = Cypress.env('CLUSTERSET')+'-'+(Math.random() + 1).toString(36).substring(4)
         clusterSetMethods.createClusterSet(clusterSetName)
-        cy.get('[data-label="Name"]').contains(clusterSetName).click()
+        cy.contains(clusterSetName, {timeout: 3000}).should('exist').click()
         cy.get('.pf-c-nav__link').contains('Submariner add-ons').should('exist')
         clusterSetMethods.deleteClusterSet(clusterSetName)
     })
 })
-


### PR DESCRIPTION
Submariner_addon test fails randomly, when created clusterset takes a few seconds to appear sometimes.
If it does not appear right away, the test fails as it unable to find the expected clusterset.

Replace the "cy.get" with "cy.contains" and add a timeout for the clusterset expect after creation.