### PR TITLE
Add connection check to datagrepper query

### DIFF
--- a/lib/submariner_prepare/downstream_prepare.sh
+++ b/lib/submariner_prepare/downstream_prepare.sh
@@ -38,7 +38,12 @@ function get_latest_iib() {
         | {nvr: .artifact.nvr, index_image: .pipeline.index_image}] | .[0]'
 
     umb_output=$(curl --retry 30 --retry-delay 5 -k -Ls \
-        "${umb_url}&rows_per_page=${rows}&delta=${delta}&contains=${bundle_name}-container-v${submariner_version}")
+        "${umb_url}&rows_per_page=${rows}&delta=${delta}&contains=${bundle_name}-container-v${submariner_version}" || :)
+
+    if [[ "$umb_output" == "" ]]; then
+        ERROR "Unable to fetch IIB data. Verify VPN connection"
+    fi
+
     index_images=$(echo "$umb_output" | jq -r "$iib_query")
 
     if [[ "$index_images" == "null" ]]; then


### PR DESCRIPTION
Deployment of downstream submariner require a query from the datagrepper resource.
Datagrepper reside within red hat network, which means VPN is required to perform the query.

Add verification check and message to ensure that is not output received, the user should check the VPN connection.