### PR TITLE
Execute API tests by tags

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,6 +49,8 @@ pipeline {
                     environment name: 'TEST_TAGS', value: '@e2e'
                     environment name: 'TEST_TAGS', value: '@Submariner'
                     environment name: 'TEST_TAGS', value: '@post-release'
+                    environment name: 'TEST_TAGS', value: '@api'
+                    environment name: 'TEST_TAGS', value: '@api-post-release'
                 }
             }
             steps {
@@ -148,10 +150,16 @@ pipeline {
                     if (params.TEST_TAGS == '@post-release') {
                         DOWNSTREAM = "--downstream false"
                     }
+
+                    TESTS_TYPE = "--test-type e2e,ui"
+                    if (params.TEST_TAGS == '@api' ||
+                        params.TEST_TAGS == '@api-post-release') {
+                            TESTS_TYPE = "--test-type e2e"
+                        }
                 }
 
                 sh """
-                ./run.sh --test --platform "${params.PLATFORM}" $DOWNSTREAM
+                ./run.sh --test --platform "${params.PLATFORM}" $DOWNSTREAM $TESTS_TYPE
                 """
             }
         }


### PR DESCRIPTION
According to acm-qe pipeline triggering when using "@api" and "@api-post-release" test tags only api tests should be executed.

https://issues.redhat.com/browse/ACM-3969