### PR TITLE
Add pipeline specific part to execute

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,6 +22,7 @@ pipeline {
         booleanParam(name: 'SUBMARINER_GATEWAY_RANDOM', defaultValue: true, description: 'Deploy two submariner gateways on one of the clusters')
         string(name:'TEST_TAGS', defaultValue: '', description: 'A tag to control job execution')
         booleanParam(name: 'POLARION', defaultValue: true, description: 'Publish tests results to Polarion')
+        choice(name: 'JOB_STAGES', choices: ['all', 'deploy', 'test'], description: 'Select stage that should be executed by the job')
     }
     environment {
         EXECUTE_JOB = false
@@ -90,8 +91,11 @@ pipeline {
         }
         stage('Deploy') {
             when {
-                expression {
-                    EXECUTE_JOB == true
+                allOf {
+                    expression {
+                        EXECUTE_JOB == true
+                        JOB_STAGES == 'all' || JOB_STAGES == 'deploy'
+                    }
                 }
             }
             steps {
@@ -100,7 +104,7 @@ pipeline {
                     // The "GLOBALNET_TRIGGER" will be used as a
                     // control point to for ACM versions below 2.5.0
                     // As it's not supported.
-                    if (!GLOBALNET_TRIGGER) {
+                    if (GLOBALNET_TRIGGER.toBoolean() == false) {
                         GLOBALNET = "--globalnet false"
                     }
 
@@ -131,8 +135,11 @@ pipeline {
         }
         stage('Test') {
             when {
-                expression {
-                    EXECUTE_JOB == true
+                allOf {
+                    expression {
+                        EXECUTE_JOB == true
+                        JOB_STAGES == 'all' || JOB_STAGES == 'test'
+                    }
                 }
             }
             steps {
@@ -157,8 +164,11 @@ pipeline {
         }
         stage('Report to Polarion') {
             when {
-                expression {
-                    EXECUTE_JOB == true
+                allOf {
+                    expression {
+                        EXECUTE_JOB == true
+                        JOB_STAGES == 'all' || JOB_STAGES == 'test'
+                    }
                 }
             }
             steps {


### PR DESCRIPTION
Add option to execute only part of the pipeline.
For example, perform only submariner deployment.
Or execute only test phase.

The option will be exposed as parameter in jenkins job.