### PR TITLE
Print manifests dir path after cluster creation

### DIFF
--- a/roles/ocp/tasks/fetch_details.yml
+++ b/roles/ocp/tasks/fetch_details.yml
@@ -38,5 +38,7 @@
       Cluster console: {{ cluster_console }}
       Cluster api: {{ cluster_url }}
       Cluster pass: {{ cluster_pass }}
+
+      Cluster manifests files could be found here: {{ working_path }}/{{ item.name }}/
   ansible.builtin.debug:
     msg: "{{ msg.split('\n') }}"


### PR DESCRIPTION
Specify manifest directory as details output after cluster creation.