### PR TITLE
Create "cluster_login" role

### DIFF
--- a/roles/cluster_login/defaults/main.yml
+++ b/roles/cluster_login/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+cluster_url:
+cluster_user: kubeadmin
+cluster_pass:
+
+cluster_api_token:

--- a/roles/cluster_login/tasks/main.yml
+++ b/roles/cluster_login/tasks/main.yml
@@ -1,0 +1,18 @@
+---
+- name: Allocate cluster connection details
+  ansible.builtin.set_fact:
+    cluster_url: "{{ lookup('env', 'OC_CLUSTER_URL') | default(cluster_url) }}"
+    cluster_user: "{{ lookup('env', 'OC_CLUSTER_USER') | default(cluster_user) }}"
+    cluster_pass: "{{ lookup('env', 'OC_CLUSTER_PASS') | default(cluster_pass) }}"
+
+- name: Log in to "{{ cluster_url }}" (obtain access token)
+  community.okd.openshift_auth:
+    host: "{{ cluster_url }}"
+    username: "{{ cluster_user }}"
+    password: "{{ cluster_pass }}"
+    validate_certs: no
+  register: ocp_auth
+
+- name: Set "{{ cluster_url }}" authentication token
+  ansible.builtin.set_fact:
+    cluster_api_token: "{{ ocp_auth.openshift_auth.api_key }}"


### PR DESCRIPTION
The "cluster_login" role will get cluster authentication details and obtain token to be used by other modules to authenticate the ocp cluster.