### PR TITLE
Fix env vars assignment on cluster_login role

### DIFF
--- a/roles/cluster_login/tasks/main.yml
+++ b/roles/cluster_login/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
 - name: Allocate cluster connection details
   ansible.builtin.set_fact:
-    cluster_url: "{{ lookup('env', 'OC_CLUSTER_URL') | default(cluster_url) }}"
-    cluster_user: "{{ lookup('env', 'OC_CLUSTER_USER') | default(cluster_user) }}"
-    cluster_pass: "{{ lookup('env', 'OC_CLUSTER_PASS') | default(cluster_pass) }}"
+    cluster_url: "{{ lookup('env', 'OC_CLUSTER_URL') | default(cluster_url, true) }}"
+    cluster_user: "{{ lookup('env', 'OC_CLUSTER_USER') | default(cluster_user, true) }}"
+    cluster_pass: "{{ lookup('env', 'OC_CLUSTER_PASS') | default(cluster_pass, true) }}"
 
 - name: Log in to "{{ cluster_url }}" (obtain access token)
   community.okd.openshift_auth:


### PR DESCRIPTION
The flow of variables assignment should be the following: If any of the "OC_CLUSTER_URL", "OC_CLUSTER_USER" or "OC_CLUSTER_PASS" environment variables exists, it should be used, otherwise, fall back to ansible "cluster_url", "cluster_user" and "cluster_pass" variables.