### PR TITLE
Add CSV validation to MCH deployment

### DIFF
--- a/roles/acm/tasks/deploy.yml
+++ b/roles/acm/tasks/deploy.yml
@@ -74,7 +74,7 @@
     validate_certs: no
     definition: "{{ lookup('template', 'subscription.yaml.j2') | from_yaml }}"
 
-- name: Fetch the name of install ClusterServiceVersion
+- name: Fetch the name of installed ClusterServiceVersion
   kubernetes.core.k8s_info:
     host: "{{ cluster_url }}"
     api_key: "{{ cluster_api_token }}"
@@ -84,6 +84,25 @@
     name: acm-operator-subscription
     namespace: "{{ acm_namespace }}"
   register: acm_subscription
+  until: "'currentCSV' in acm_subscription.resources[0].status"
+  retries: 15
+  delay: 10
+
+- name: Wait for the ClusterServiceVersion to succeeded install
+  kubernetes.core.k8s_info:
+    host: "{{ cluster_url }}"
+    api_key: "{{ cluster_api_token }}"
+    validate_certs: no
+    api_version: operators.coreos.com/v1alpha1
+    kind: ClusterServiceVersion
+    name: "{{ acm_subscription.resources[0].status.currentCSV }}"
+    namespace: "{{ acm_namespace }}"
+  register: acm_csv
+  until:
+    - acm_csv.resources | length > 0
+    - acm_csv.resources[0].status.phase == "Succeeded"
+  retries: 15
+  delay: 10
 
 - name: Deploy MultiClusterHub
   community.okd.k8s:
@@ -96,17 +115,3 @@
     wait_condition:
       type: Complete
       status: True
-
-- name: Wait for the ClusterServiceVersion to succeeded install
-  kubernetes.core.k8s_info:
-    host: "{{ cluster_url }}"
-    api_key: "{{ cluster_api_token }}"
-    validate_certs: no
-    api_version: operators.coreos.com/v1alpha1
-    kind: ClusterServiceVersion
-    name: "{{ acm_subscription.resources[0].status.currentCSV }}"
-    namespace: "{{ acm_namespace }}"
-  register: acm_csv
-  until: acm_csv.resources[0].status.phase == "Succeeded"
-  retries: 15
-  delay: 10

--- a/roles/acm/tasks/main.yml
+++ b/roles/acm/tasks/main.yml
@@ -51,8 +51,9 @@
 - name: Print MultiClusterHub details
   vars:
     msg: |
-      Details of MultiClusterHub cluster:
+      Deployment of MultiClusterHub succeeded.
 
+      Cluster details:
       Cluster console: {{ cluster_console }}
       Cluster api: {{ cluster_url }}
       Cluster pass: {{ cluster_pass }}

--- a/roles/ocp/tasks/fetch_details.yml
+++ b/roles/ocp/tasks/fetch_details.yml
@@ -33,8 +33,9 @@
 - name: Print "{{ item.name }}" cluster details
   vars:
     msg: |
-      Details of {{ item.name }} cluster:
+      Deployment of {{ item.name }} cluster succeeded.
 
+      Cluster details:
       Cluster console: {{ cluster_console }}
       Cluster api: {{ cluster_url }}
       Cluster pass: {{ cluster_pass }}

--- a/roles/ocp/tasks/main.yml
+++ b/roles/ocp/tasks/main.yml
@@ -5,6 +5,7 @@
   loop:
     - "{{ pull_secret }}"
     - "{{ ssh_pub_key }}"
+  no_log: true
 
 - name: Set ocp assets path
   ansible.builtin.set_fact:


### PR DESCRIPTION
- Validate CSV for for multiclusterhub subscription has been applied and suceeded before starting multiclusterhub deployment.
- Modify ocp and acm succeed output with cluster details.
- Add "no_log: true" to ocp required parameters validation to not print the pull_secret and ssh_pub_key into the console output.