### PR TITLE
Use a single subctl archive name

### DIFF
--- a/lib/common/prerequisites.sh
+++ b/lib/common/prerequisites.sh
@@ -97,8 +97,6 @@ function get_subctl_for_testing() {
     local image_prefix="$REGISTRY_IMAGE_PREFIX"
     local subctl_version
     local subctl_download_url
-    local subctl_archive
-    local subctl_bin
     subctl_version=$(fetch_submariner_addon_version | cut -d '-' -f1)
 
     if [[ "$DOWNSTREAM" == "true" ]]; then
@@ -106,6 +104,7 @@ function get_subctl_for_testing() {
         subctl_download_url="$VPN_REGISTRY/$REGISTRY_IMAGE_IMPORT_PATH/$image_prefix-subctl-rhel8:$subctl_version"
         INFO "Download subctl from - $subctl_download_url"
         oc image extract --insecure=true "$subctl_download_url" --path=/dist/subctl-*-linux-amd64.tar.xz:./ --confirm
+        mv subctl-*-linux-amd64.tar.xz subctl.tar.xz
 
         # Untill the https://github.com/submariner-io/subctl/pull/526 patch will be available downstream,
         # use upstream subctl binary
@@ -126,13 +125,11 @@ function get_subctl_for_testing() {
     INFO "Submariner addon version - $subctl_version"
     INFO "Download subctl from - $subctl_download_url"
 
-    subctl_archive=$(find . -maxdepth 1 -name "subctl*tar.xz")
-    tar xfJ "$subctl_archive" --strip-components 1
-    subctl_bin=$(find . -maxdepth 1 -name "subctl*linux-amd64")
+    tar xfJ subctl.tar.xz --strip-components 1
 
     mkdir -p "$HOME"/.local/bin
-    cp "$subctl_bin" "$HOME"/.local/bin/subctl
-    rm -rf "$subctl_bin" "$subctl_archive"
+    install subctl*linux-amd64 "$HOME"/.local/bin/subctl
+    rm -f subctl.tar.xz subctl*linux-amd64
 
     # Add local BIN dir to PATH
     [[ ":$PATH:" == *":$HOME/.local/bin:"* ]] || export PATH="$HOME/.local/bin:$PATH"


### PR DESCRIPTION
Currently, if run.sh is used for downstream and upstream tests, but runs into errors, the downloaded archives can be left in place, with different names: subctl-...-linux-amd64.tar.xz extracted from the downstream image, or subctl.tar.xz downloaded from GitHub.

Instead of keeping the image archive name, using subctl.tar.xz in all cases avoids such errors, and allows the script to be simplified; find no longer needs to be used, and the tar command can be directly given the right file name to use.

Similarly, the subctl binary can be handled using shell globs, without find. Using install instead of cp ensures that the file is executable after installation, regardless of its permissions in the archive.