### PR TITLE
Align state variable across roles

### DIFF
--- a/playbooks/env_deploy.yml
+++ b/playbooks/env_deploy.yml
@@ -1,6 +1,9 @@
 - name: Deploy OCP and ACM environment
   hosts: localhost
   gather_facts: false
+  vars:
+    state: present
   roles:
     - ocp
     - acm
+    - managed_cluster

--- a/playbooks/env_destroy.yml
+++ b/playbooks/env_destroy.yml
@@ -1,0 +1,8 @@
+- name: Destroy OCP and ACM environment
+  hosts: localhost
+  gather_facts: false
+  vars:
+    state: absent
+  roles:
+    - managed_cluster
+    - ocp

--- a/roles/acm/README.md
+++ b/roles/acm/README.md
@@ -79,5 +79,5 @@ The variables could be applied to the playbook run, by saving them into a separa
 Note the '@' sign, which is used to apply the variables located within the provided file.
 
 ```
-ansible-playbook playbooks/ocp.yml -e @/path/to/the/variable/file.yml
+ansible-playbook playbooks/acm.yml -e @/path/to/the/variable/file.yml
 ```

--- a/roles/ocp/README.md
+++ b/roles/ocp/README.md
@@ -7,9 +7,9 @@ The role will generate the `install-config.yaml` file based on the user input an
 ## Role default variables
 #### State of the cluster
 Create or destroy the cluster.  
-The state could be 'create' or 'destroy'.
+The state could be 'present' or 'absent'.
 ```
-cluster_state: create
+state: present
 ```
 
 #### OpenShift pull secret

--- a/roles/ocp/defaults/main.yml
+++ b/roles/ocp/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Set the cluster state of the execution
-# The state could be 'create' or 'destroy'.
-cluster_state: create
+# The state could be 'present' or 'absent'.
+state: present
 
 # OpenShift pull secret
 pull_secret:

--- a/roles/ocp/tasks/main.yml
+++ b/roles/ocp/tasks/main.yml
@@ -43,21 +43,27 @@
         dest: "/tmp/"
         remote_src: yes
 
-    - name: OCP cluster {{ cluster_state }}
+    - name: "OCP cluster - {{ cluster_state }}"
+      vars:
+        cluster_state: "{%- if state == 'present' -%}
+                        create
+                        {%- elif state == 'absent' -%}
+                        destroy
+                        {%- endif -%}"
       ansible.builtin.command:
         cmd: "/tmp/openshift-install {{ cluster_state }} cluster --dir {{ working_path }}/{{ item.name }}/"
       loop: "{{ clusters }}"
-  when: deploy_cluster | bool or cluster_state == "destroy"
+  when: deploy_cluster | bool or state == "absent"
 
 - name: Delete assets directory when cluster destroyed
   ansible.builtin.file:
     path: "{{ working_path }}/{{ item.name }}/"
     state: absent
   loop: "{{ clusters }}"
-  when: cluster_state == "destroy"
+  when: state == "absent"
 
 - name: Fetch OCP cluster details
   ansible.builtin.include_tasks:
     file: fetch_details.yml
   loop: "{{ clusters }}"
-  when: cluster_state == "create"
+  when: state == "present"


### PR DESCRIPTION
- Align state variable across roles When using playbook with multiple roles (ocp, acm, managed_cluster) to create full environment, better to use single "state" variable for creation/deletion of the resources. The variable will be - `state` and accepted variables - preset/absent.
- Create a separate playbooks for env creation and env destroy.