### PR TITLE
Modify check for install acm hub

### DIFF
--- a/roles/acm/tasks/main.yml
+++ b/roles/acm/tasks/main.yml
@@ -19,7 +19,7 @@
 - name: Set updated state of MultiClusterHub
   ansible.builtin.set_fact:
     deploy_mch: false
-  when: mch_state.api_found | bool
+  when: mch_state.resources != []
 
 - name: Print when MCH already installed
   ansible.builtin.debug:


### PR DESCRIPTION
On some environments, "api_found" return "true" although it doesn't exist.
Modify the check for installed acm hub by checking the resources list to be empty.