### PR TITLE
[managed_cluster role] Add images architecture selection

### DIFF
--- a/roles/managed_cluster/tasks/cluster_deployment.yml
+++ b/roles/managed_cluster/tasks/cluster_deployment.yml
@@ -1,6 +1,7 @@
 ---
 # curl -s -X GET https://quay.io/api/v1/repository/openshift-release-dev/ocp-release/tag/ \
-# | jq -S '.tags[] | {name: .name} | select(.name | startswith("4.11"))' | jq -r '.name' | head -1
+# | jq -S '.tags[] | {name: .name} | select(.name | startswith("4.9")) | select(.name | endswith("x86_64"))' \
+# | jq -r '.name'
 - name: Fetch cluster image if not provided manually
   ansible.builtin.uri:
     url: "{{ ocp_image_query_url }}"
@@ -12,7 +13,7 @@
 - name: Select latest cluster image according to provided version
   ansible.builtin.set_fact:
     managed_cluster_ver: "{{ img.json.tags
-      | selectattr('name', 'match', item.managed_cluster_version | string)
+      | selectattr('name', 'match', item.managed_cluster_version + '.*' + cluster_architecture | string)
       | map(attribute='name') | first }}"
   when: item.managed_cluster_image is not defined
 

--- a/roles/managed_cluster/vars/main.yml
+++ b/roles/managed_cluster/vars/main.yml
@@ -1,6 +1,10 @@
 ocp_image_query_url: https://quay.io/api/v1/repository/openshift-release-dev/ocp-release/tag/
 ocp_image_base_url: quay.io/openshift-release-dev/ocp-release
 
+# Architecture of the managed clusters
+# Allowed values: x86_64, s390x, ppc64le, aarch64
+cluster_architecture: "x86_64"
+
 platform_resources:
   aws:
     master_resource:


### PR DESCRIPTION
Images for managed cluster have number of architectures. In order to fetch the right image with the right architecture, add the cluster_architecture variable to fetch the exact image.