### PR TITLE
Fix Jenkinsfile stages trigger

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -97,6 +97,8 @@ pipeline {
                 allOf {
                     expression {
                         EXECUTE_JOB == true
+                    }
+                    expression {
                         JOB_STAGES == 'all' || JOB_STAGES == 'deploy'
                     }
                 }
@@ -141,6 +143,8 @@ pipeline {
                 allOf {
                     expression {
                         EXECUTE_JOB == true
+                    }
+                    expression {
                         JOB_STAGES == 'all' || JOB_STAGES == 'test'
                     }
                 }
@@ -176,6 +180,8 @@ pipeline {
                 allOf {
                     expression {
                         EXECUTE_JOB == true
+                    }
+                    expression {
                         JOB_STAGES == 'all' || JOB_STAGES == 'test'
                     }
                 }


### PR DESCRIPTION
Triggering of the stages didn't work correctly when environment was not ready.
The "deploy", "test" and "report" stages should be skipped if the env provided does not meet requirements.