### PR TITLE
Fix typo on ocp role README

### DIFF
--- a/roles/ocp/README.md
+++ b/roles/ocp/README.md
@@ -42,7 +42,7 @@ clusters:
       platform: aws
       region: us-east-2
       instance_type: m5.xlarge
-    openshift_version: "4/12"  # Optional variable to set OCP version per cluster
+    openshift_version: "4.12"  # Optional variable to set OCP version per cluster
 ```
 
 #### Openshift version


### PR DESCRIPTION
The ofenshift version was written with "/" instead of with "."