### PR TITLE
[OCP role] - Add cloud creds set

### DIFF
--- a/roles/ocp/README.md
+++ b/roles/ocp/README.md
@@ -42,7 +42,17 @@ clusters:
       platform: aws
       region: us-east-2
       instance_type: m5.xlarge
+    creds_type: aws
     openshift_version: "4.12"  # Optional variable to set OCP version per cluster
+```
+
+#### Clusters credentials
+Credentials that should be used during openshift cluster deployment
+```
+clusters_credentials:
+  aws:
+    aws_access_key_id: <your_key_id>
+    aws_secret_access_key: <your_access_key>
 ```
 
 #### Openshift version

--- a/roles/ocp/defaults/main.yml
+++ b/roles/ocp/defaults/main.yml
@@ -11,6 +11,7 @@ ssh_pub_key:
 clusters:
   - name: test-cluster
     base_domain: example.com
+    creds_type: aws
     network:
       cluster: 10.128.0.0/14
       machine: 10.0.0.0/16
@@ -21,6 +22,11 @@ clusters:
       region: us-east-2
       instance_type: m5.xlarge
     openshift_version: "4.12"  # Optional variable to set OCP version per cluster
+
+clusters_credentials:
+  aws:
+    aws_access_key_id: <your_key>
+    aws_secret_access_key: <your_secret_key>
 
 openshift_version:
 openshift_install_binary: openshift-install-linux.tar.gz

--- a/roles/ocp/tasks/main.yml
+++ b/roles/ocp/tasks/main.yml
@@ -34,6 +34,7 @@
 - name: Prepare OCP cluster configuration
   ansible.builtin.include_tasks:
     file: prepare.yml
+  loop: "{{ clusters }}"
   when: deploy_cluster | bool
 
 - name: Process OpenShift

--- a/roles/ocp/tasks/prepare.yml
+++ b/roles/ocp/tasks/prepare.yml
@@ -1,18 +1,35 @@
 ---
+- name: Verify openshift cloud credentials
+  ansible.builtin.stat:
+    path: "{{ lookup('env', 'HOME') }}/.{{ item.creds_type }}/credentials"
+  register: cloud_creds
+
+- block:
+    - name: Create platform creds directory
+      ansible.builtin.file:
+        path: "{{ lookup('env', 'HOME') }}/.{{ item.creds_type }}"
+        mode: 0755
+        state: directory
+
+    - name: Create cloud credentials file
+      ansible.builtin.template:
+        src: cloud-creds.j2
+        dest: "{{ lookup('env', 'HOME') }}/.{{ item.creds_type }}/credentials"
+        mode: 0600
+  when: not cloud_creds.stat.exists
+
 - name: Create OCP working directory
   ansible.builtin.file:
     path: "{{ working_path }}"
     state: directory
     recurse: yes
 
-- name: Create OCP assets directory
+- name: Create OCP assets directory for "{{ item.name }}" cluster
   ansible.builtin.file:
     path: "{{ working_path }}/{{ item.name }}"
     state: directory
-  loop: "{{ clusters }}"
 
 - name: Generate install-config.yaml for OCP cluster deployment
   ansible.builtin.template:
     src: install-config.yaml.j2
     dest: "{{ working_path }}/{{ item.name }}/install-config.yaml"
-  loop: "{{ clusters }}"

--- a/roles/ocp/templates/cloud-creds.j2
+++ b/roles/ocp/templates/cloud-creds.j2
@@ -1,0 +1,5 @@
+{% if item.creds_type == "aws" %}
+[default]
+aws_access_key_id = {{ clusters_credentials[item.creds_type].aws_access_key_id }}
+aws_secret_access_key = {{ clusters_credentials[item.creds_type].aws_secret_access_key }}
+{% endif %}


### PR DESCRIPTION
When deploying ocp cluster on machine which doesn't has cloud credentials configured, creation of the cloud will fail.

Add credentials set for credentials if not exists. Currently, adding "AWS" cloud credentials.