### PR TITLE
Remove "--no-deps" argument from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN wget -qO- "$OCP_CLI" | tar zxv -C /usr/local/bin/ oc kubectl \
 
 COPY requirements.txt requirements.yml ./
 
-RUN pip install --no-deps --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 USER "$SUBM"
 


### PR DESCRIPTION
The "pip install" command should not contain "--no-deps" argument, othervise next command will fail.