### PR TITLE
Add "openshift_channel" to the ocp role.

### DIFF
--- a/roles/ocp/README.md
+++ b/roles/ocp/README.md
@@ -62,6 +62,13 @@ By default will deploy the latest stable.
 openshift_version:
 ```
 
+#### Openshift channel
+The channel the should be used alongside with the version.  
+Available values: 'stable', 'latest', 'candidate'.
+```
+openshift_channel: stable
+```
+
 #### Openshift binary name
 The name of the archived binary of openshift-install.
 ```

--- a/roles/ocp/defaults/main.yml
+++ b/roles/ocp/defaults/main.yml
@@ -29,6 +29,8 @@ clusters_credentials:
     aws_secret_access_key: <your_secret_key>
 
 openshift_version:
+# Available: 'stable', 'latest', 'candidate'
+openshift_channel: stable
 openshift_install_binary: openshift-install-linux.tar.gz
 openshift_install_url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp
 ocp_assets_dir: logs/ocp_assets

--- a/roles/ocp/tasks/deploy.yml
+++ b/roles/ocp/tasks/deploy.yml
@@ -2,11 +2,11 @@
 - name: Set the version of openshift-install binary to download
   ansible.builtin.set_fact:
     ocp_version: "{%- if item.openshift_version is defined -%}
-                  stable-{{ item.openshift_version }}
+                  {{ openshift_channel }}-{{ item.openshift_version }}
                   {%- elif openshift_version is not none -%}
-                  stable-{{ openshift_version }}
+                  {{ openshift_channel }}-{{ openshift_version }}
                   {%- else -%}
-                  stable
+                  {{ openshift_channel }}
                   {%- endif -%}"
 
 - name: Print selected openshift-install version


### PR DESCRIPTION
When deploying ocp, we could choose a version of the openshift. By default it supports deployment from "stable" channel. Add support for other channels like, "latest" and "candidate".