### PR TITLE
Add "report_suffix" variable to the end of the tests basename string.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ export OC_CLUSTER_PASS=<password of the cluster user>
                              (Optional)
                              By default - e2e,ui
 
+    --report-suffix        - Add suffix to the tests basename.
+                             (Optional)
+                             By default - empty string
+
     Submariner configuration arguments:
     -----------------------------------
     --globalnet            - Set the state of the Globalnet for the Submariner deployment.

--- a/lib/common/helper_functions.sh
+++ b/lib/common/helper_functions.sh
@@ -104,6 +104,10 @@ function usage() {
                              (Optional)
                              By default - e2e,ui
 
+    --report-suffix        - Add suffix to the tests basename.
+                             (Optional)
+                             By default - empty string
+
     Submariner configuration arguments:
     -----------------------------------
     --globalnet            - Set the state of the Globalnet for the Submariner deployment.

--- a/lib/submariner_test/submariner_test.sh
+++ b/lib/submariner_test/submariner_test.sh
@@ -42,12 +42,17 @@ function combine_tests_basename() {
     local type="$1"  # e2e or ui
     local primary_cluster="$2"
     local secondary_cluster="$3"
+    local report_suffix
     local acm_ver
     local subm_ver
     local primary_cl_platform
     local secondary_cl_platform
     local globalnet
     local globalnet_state=""
+
+    if [[ -n "$TEST_REPORT_SUFFIX" ]]; then
+        report_suffix="-$TEST_REPORT_SUFFIX"
+    fi
 
     acm_ver=$(oc get multiclusterhub -A -o jsonpath='{.items[0].status.currentVersion}' | cut -d '-' -f1)
     subm_ver=$(KUBECONFIG="$LOGS/$primary_cluster-kubeconfig.yaml" \
@@ -73,9 +78,9 @@ function combine_tests_basename() {
         secondary_cl_version=$(oc get managedcluster "$secondary_cluster" --ignore-not-found \
             -o jsonpath='{.metadata.labels.openshiftVersion-major-minor}')
 
-        echo "ACM-${acm_ver}-Submariner-${subm_ver}-${primary_cl_platform}-${primary_cl_version}-${secondary_cl_platform}-${secondary_cl_version}-${globalnet}"
+        echo "ACM-${acm_ver}-Submariner-${subm_ver}-${primary_cl_platform}-${primary_cl_version}-${secondary_cl_platform}-${secondary_cl_version}-${globalnet}${report_suffix}"
     elif [[ "$type" == "ui" ]]; then
-        echo "ACM-${acm_ver}-Submariner-${subm_ver}-${globalnet}-UI"
+        echo "ACM-${acm_ver}-Submariner-${subm_ver}-${globalnet}-UI${report_suffix}"
     fi
 }
 

--- a/run.sh
+++ b/run.sh
@@ -206,6 +206,12 @@ function parse_arguments() {
                     shift 2
                 fi
                 ;;
+            --report-suffix)
+                if [[ -n "$2" ]]; then
+                    export TEST_REPORT_SUFFIX="$2"
+                    shift 2
+                fi
+                ;;
             --subm-ipsec-natt-port)
                 if [[ -n "$2" ]]; then
                     export SUBMARINER_IPSEC_NATT_PORT="$2"

--- a/variables
+++ b/variables
@@ -77,3 +77,6 @@ export LATEST_IIB=""
 export TEST_TYPE="e2e,ui"
 # Execute or skip UI tests. By default, execute.
 export UI_TESTS="true"
+
+# Optional addition to the test basename. By default, empty.
+export TEST_REPORT_SUFFIX=""


### PR DESCRIPTION
The content of this variable is determined using flag (--report_suffix) that was added. 
It was added in order to distinguish between the different features that are tested, for example backup and restore.