### PR TITLE
Generate clusters connection details file

### DIFF
--- a/roles/ocp/defaults/main.yml
+++ b/roles/ocp/defaults/main.yml
@@ -34,3 +34,4 @@ openshift_channel: stable
 openshift_install_binary: openshift-install-linux.tar.gz
 openshift_install_url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp
 ocp_assets_dir: logs/ocp_assets
+clusters_details_file: clusters_details.yml

--- a/roles/ocp/tasks/fetch_details.yml
+++ b/roles/ocp/tasks/fetch_details.yml
@@ -30,16 +30,24 @@
   ansible.builtin.set_fact:
     cluster_pass: "{{ cluster_pass_reg['content'] | b64decode }}"
 
+- name: Write cluster details into state file
+  ansible.builtin.blockinfile:
+    path: "{{ working_path }}/{{ clusters_details_file }}"
+    block: |
+      {{ item.name }}:
+        console: {{ cluster_console }}
+        api: {{ cluster_api }}
+        pass: {{ cluster_pass }}
+    marker: "#{mark} {{ item.name }} details"
+    create: true
+    state: present
+
 - name: Print "{{ item.name }}" cluster details
   vars:
     msg: |
       Deployment of {{ item.name }} cluster succeeded.
 
-      Cluster details:
-      Cluster console: {{ cluster_console }}
-      Cluster api: {{ cluster_url }}
-      Cluster pass: {{ cluster_pass }}
-
+      Cluster connection details could be found here: {{ working_path }}/{{ clusters_details_file }}
       Cluster manifests files could be found here: {{ working_path }}/{{ item.name }}/
   ansible.builtin.debug:
     msg: "{{ msg.split('\n') }}"

--- a/roles/ocp/tasks/main.yml
+++ b/roles/ocp/tasks/main.yml
@@ -43,11 +43,33 @@
   loop: "{{ clusters }}"
   when: deploy_cluster | bool or state == "absent"
 
-- name: Delete assets directory when cluster destroyed
-  ansible.builtin.file:
-    path: "{{ working_path }}/{{ item.name }}/"
-    state: absent
-  loop: "{{ clusters }}"
+- block:
+    - name: Delete assets directory when cluster destroyed
+      ansible.builtin.file:
+        path: "{{ working_path }}/{{ item.name }}/"
+        state: absent
+      loop: "{{ clusters }}"
+
+    - name: Write cluster details into state file
+      ansible.builtin.blockinfile:
+        path: "{{ working_path }}/{{ clusters_details_file }}"
+        block: ""
+        marker: "#{mark} {{ item.name }} details"
+        state: absent
+      loop: "{{ clusters }}"
+
+    - name: Check the "{{ clusters_details_file }}" file
+      ansible.builtin.stat:
+        path: "{{ working_path }}/{{ clusters_details_file }}"
+      register: cl_file_state
+
+    - name: Delete the "{{ clusters_details_file }}" file if empty
+      ansible.builtin.file:
+        path: "{{ working_path }}/{{ clusters_details_file }}"
+        state: absent
+      when:
+        - cl_file_state.stat.exists
+        - cl_file_state.stat.size == 0
   when: state == "absent"
 
 - name: Fetch OCP cluster details


### PR DESCRIPTION
Once creation of the clusters completes with "ocp" role, generate a "clusters_details.yml" file that will hold connection details for the clusters.
This file will be used to fetch connection details of the clusters by other roles.