### PR TITLE
Add creation of login token from cluster details file

### DIFF
--- a/roles/cluster_login/defaults/main.yml
+++ b/roles/cluster_login/defaults/main.yml
@@ -1,6 +1,5 @@
 ---
-cluster_url:
-cluster_user: kubeadmin
-cluster_pass:
+cluster_name:
 
-cluster_api_token:
+ocp_assets_dir: logs/ocp_assets
+clusters_details_file: clusters_details.yml

--- a/roles/cluster_login/tasks/main.yml
+++ b/roles/cluster_login/tasks/main.yml
@@ -1,18 +1,49 @@
 ---
+- name: Set ocp assets path
+  ansible.builtin.set_fact:
+    working_path: "{{ lookup('env', 'PWD') }}/{{ ocp_assets_dir }}"
+
+- name: Check for cluster details file
+  ansible.builtin.stat:
+    path: "{{ working_path }}/{{ clusters_details_file }}"
+  register: cl_file_state
+
+- block:
+    - name: Fetch cluster details file data as dict
+      ansible.builtin.set_fact:
+        cl_file: "{{ lookup('file', '{{ working_path }}/{{ clusters_details_file }}') | from_yaml }}"
+
+    - name: Set the hub to use if defined or first available
+      ansible.builtin.set_fact:
+        cl_name: "{%- if cluster_name -%}
+                  {{ hub_name }}
+                  {%- else -%}
+                  {{ cl_file | first }}
+                  {%- endif -%}"
+
+    - name: Set cluster details
+      ansible.builtin.set_fact:
+        cl_api: "{{ cl_file[cl_name].api }}"
+        cl_user: "{{ cl_file[cl_name].user | default('kubeadmin') }}"
+        cl_pass: "{{ cl_file[cl_name].pass }}"
+  when:
+    - cl_file_state.stat.exists
+    - cl_file_state.stat.size != 0
+
 - name: Allocate cluster connection details
   ansible.builtin.set_fact:
-    cluster_url: "{{ lookup('env', 'OC_CLUSTER_URL') | default(cluster_url, true) }}"
-    cluster_user: "{{ lookup('env', 'OC_CLUSTER_USER') | default(cluster_user, true) }}"
-    cluster_pass: "{{ lookup('env', 'OC_CLUSTER_PASS') | default(cluster_pass, true) }}"
+    cluster_api: "{{ lookup('env', 'OC_CLUSTER_URL') | default(cl_api, true) }}"
+    cluster_user: "{{ lookup('env', 'OC_CLUSTER_USER') | default(cl_user, true) }}"
+    cluster_pass: "{{ lookup('env', 'OC_CLUSTER_PASS') | default(cl_pass, true) }}"
 
-- name: Log in to "{{ cluster_url }}" (obtain access token)
+- name: Log in to "{{ cluster_api }}" (obtain access token)
   community.okd.openshift_auth:
-    host: "{{ cluster_url }}"
+    host: "{{ cluster_api }}"
     username: "{{ cluster_user }}"
     password: "{{ cluster_pass }}"
     validate_certs: no
   register: ocp_auth
 
-- name: Set "{{ cluster_url }}" authentication token
+- name: Set "{{ cluster_api }}" authentication token
   ansible.builtin.set_fact:
     cluster_api_token: "{{ ocp_auth.openshift_auth.api_key }}"


### PR DESCRIPTION
The "cluster_login" role fetch openshift login token from environment varialbes.
As newly created ocp clusters details are placed into the "cluster_details.yml" file, modify the cluster_login role to use these connection details to obtin a tcken.