### PR TITLE
Fetch explicit ocp image / acm version from quay

### DIFF
--- a/roles/acm/tasks/deploy.yml
+++ b/roles/acm/tasks/deploy.yml
@@ -3,7 +3,7 @@
 # | jq -S '.tags[] | {name: .name} | select(.name | startswith("2.8"))' | jq -r '.name' | head -1
 - name: Fetch downstream snapshots if snapshot not provided manually
   ansible.builtin.uri:
-    url: "{{ registry_query_url }}"
+    url: "{{ registry_query_url }}/?filter_tag_name=like:{{ acm_version }}"
     method: "GET"
     status_code: 200
   register: snap

--- a/roles/managed_cluster/tasks/cluster_deployment.yml
+++ b/roles/managed_cluster/tasks/cluster_deployment.yml
@@ -1,10 +1,9 @@
 ---
-# curl -s -X GET https://quay.io/api/v1/repository/openshift-release-dev/ocp-release/tag/ \
-# | jq -S '.tags[] | {name: .name} | select(.name | startswith("4.9")) | select(.name | endswith("x86_64"))' \
-# | jq -r '.name'
+# curl -s -X GET https://quay.io/api/v1/repository/openshift-release-dev/ocp-release/tag/?filter_tag_name=like:4.9 \
+# | jq -S '.tags[] | {name: .name} | select(.name | endswith("x86_64"))' | jq -r '.name'
 - name: Fetch cluster image if not provided manually
   ansible.builtin.uri:
-    url: "{{ ocp_image_query_url }}"
+    url: "{{ ocp_image_query_url }}/?filter_tag_name=like:{{ item.managed_cluster_version }}"
     method: "GET"
     status_code: 200
   register: img


### PR DESCRIPTION
When fetching a version of the ocp for the managed cluster or an acm version from quay, could be that the required version exists not on the first page.
As a result, required version will not be fetched and deployment will fail..
To solve it, add the following filter to the query: "?filter_tag_name=like:<tag_version>".
It will query explicit version of the image, for example: 4.11 and return a list of available versions:
- 4.11.59
- 4.11.58 etc...