### PR TITLE
Fix Jenkinsfile junit path

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -203,7 +203,7 @@ pipeline {
     post {
         always {
             archiveArtifacts artifacts: "logs/**/*.*", followSymlinks: false, allowEmptyArchive: true
-            junit allowEmptyResults: true, testResults: "logs/**/*junit.xml"
+            junit allowEmptyResults: true, testResults: "logs/**/**/*junit.xml"
         }
     }
 }


### PR DESCRIPTION
Junit files path has been changed due to the folders restructure made. Update the path to get the tests results.