### PR TITLE
Added cluster search by name in the search bar in the addon cypress test

### DIFF
--- a/cypress/cypress/e2e/04_submariner_addon.cy.js
+++ b/cypress/cypress/e2e/04_submariner_addon.cy.js
@@ -23,7 +23,8 @@ describe('submariner - validate submariner addon tab', {
     it('test the Submariner add-ons', { tags: ['addon'] }, function () {
         let clusterSetName = Cypress.env('CLUSTERSET')+'-'+(Math.random() + 1).toString(36).substring(4)
         clusterSetMethods.createClusterSet(clusterSetName)
-        cy.contains(clusterSetName, {timeout: 3000}).should('exist').click()
+        cy.get('.pf-c-text-input-group__text-input').type(clusterSetName)
+        cy.contains(clusterSetName).should('exist').click({timeout: 3000})
         cy.get('.pf-c-nav__link').contains('Submariner add-ons').should('exist')
         clusterSetMethods.deleteClusterSet(clusterSetName)
     })


### PR DESCRIPTION
The addon UI test failed When there were several pages of cluster sets therefore a search (in the search bar) for the cluster name was added.