### PR TITLE
Do not expose passwords to console output

### DIFF
--- a/roles/acm/tasks/main.yml
+++ b/roles/acm/tasks/main.yml
@@ -56,6 +56,5 @@
       Cluster details:
       Cluster console: {{ cluster_console }}
       Cluster api: {{ cluster_api }}
-      Cluster pass: {{ cluster_pass }}
   ansible.builtin.debug:
     msg: "{{ msg.split('\n') }}"

--- a/roles/cluster_login/tasks/main.yml
+++ b/roles/cluster_login/tasks/main.yml
@@ -12,6 +12,7 @@
     - name: Fetch cluster details file data as dict
       ansible.builtin.set_fact:
         cl_file: "{{ lookup('file', '{{ working_path }}/{{ clusters_details_file }}') | from_yaml }}"
+      no_log: true
 
     - name: Set the hub to use if defined or first available
       ansible.builtin.set_fact:
@@ -26,6 +27,7 @@
         cl_api: "{{ cl_file[cl_name].api }}"
         cl_user: "{{ cl_file[cl_name].user | default('kubeadmin') }}"
         cl_pass: "{{ cl_file[cl_name].pass }}"
+      no_log: true
   when:
     - cl_file_state.stat.exists
     - cl_file_state.stat.size != 0
@@ -35,6 +37,7 @@
     cluster_api: "{{ lookup('env', 'OC_CLUSTER_URL') | default(cl_api, true) }}"
     cluster_user: "{{ lookup('env', 'OC_CLUSTER_USER') | default(cl_user, true) }}"
     cluster_pass: "{{ lookup('env', 'OC_CLUSTER_PASS') | default(cl_pass, true) }}"
+  no_log: true
 
 - name: Log in to "{{ cluster_api }}" (obtain access token)
   community.okd.openshift_auth:
@@ -43,7 +46,9 @@
     password: "{{ cluster_pass }}"
     validate_certs: no
   register: ocp_auth
+  no_log: true
 
 - name: Set "{{ cluster_api }}" authentication token
   ansible.builtin.set_fact:
     cluster_api_token: "{{ ocp_auth.openshift_auth.api_key }}"
+  no_log: true

--- a/roles/ocp/tasks/fetch_details.yml
+++ b/roles/ocp/tasks/fetch_details.yml
@@ -13,6 +13,7 @@
   ansible.builtin.slurp:
     src: "{{ working_path }}/{{ item.name }}/auth/kubeadmin-password"
   register: cluster_pass_reg
+  no_log: true
 
 - name: Set OCP cluster console
   ansible.builtin.set_fact:
@@ -29,6 +30,7 @@
 - name: Set OCP cluster password
   ansible.builtin.set_fact:
     cluster_pass: "{{ cluster_pass_reg['content'] | b64decode }}"
+  no_log: true
 
 - name: Write cluster details into state file
   ansible.builtin.blockinfile:


### PR DESCRIPTION
Passwords from cluster deployment should not be printed to console output during playbook execution.
They should be placed within a separate file and fetched from there.