### PR TITLE
[ocp role] Separate cloud credentials prepare

### DIFF
--- a/roles/ocp/tasks/creds.yml
+++ b/roles/ocp/tasks/creds.yml
@@ -1,0 +1,19 @@
+---
+- name: Verify openshift cloud credentials
+  ansible.builtin.stat:
+    path: "{{ lookup('env', 'HOME') }}/.{{ item.creds_type }}/credentials"
+  register: cloud_creds
+
+- block:
+    - name: Create platform creds directory
+      ansible.builtin.file:
+        path: "{{ lookup('env', 'HOME') }}/.{{ item.creds_type }}"
+        mode: 0755
+        state: directory
+
+    - name: Create cloud credentials file
+      ansible.builtin.template:
+        src: cloud-creds.j2
+        dest: "{{ lookup('env', 'HOME') }}/.{{ item.creds_type }}/credentials"
+        mode: 0600
+  when: not cloud_creds.stat.exists

--- a/roles/ocp/tasks/main.yml
+++ b/roles/ocp/tasks/main.yml
@@ -31,6 +31,11 @@
     msg: "OpenShift cluster already deployed. Fetching details..."
   when: not deploy_cluster | bool
 
+- name: Prepare cloud credentials
+  ansible.builtin.include_tasks:
+    file: creds.yml
+  loop: "{{ clusters }}"
+
 - name: Prepare OCP cluster configuration
   ansible.builtin.include_tasks:
     file: prepare.yml

--- a/roles/ocp/tasks/prepare.yml
+++ b/roles/ocp/tasks/prepare.yml
@@ -1,23 +1,4 @@
 ---
-- name: Verify openshift cloud credentials
-  ansible.builtin.stat:
-    path: "{{ lookup('env', 'HOME') }}/.{{ item.creds_type }}/credentials"
-  register: cloud_creds
-
-- block:
-    - name: Create platform creds directory
-      ansible.builtin.file:
-        path: "{{ lookup('env', 'HOME') }}/.{{ item.creds_type }}"
-        mode: 0755
-        state: directory
-
-    - name: Create cloud credentials file
-      ansible.builtin.template:
-        src: cloud-creds.j2
-        dest: "{{ lookup('env', 'HOME') }}/.{{ item.creds_type }}/credentials"
-        mode: 0600
-  when: not cloud_creds.stat.exists
-
 - name: Create OCP working directory
   ansible.builtin.file:
     path: "{{ working_path }}"


### PR DESCRIPTION
In ocp role, separate cloud credentials prepare from cluster configuration prepare.
When cluster deleted, configuration is not prepared but cloud credentials could be missing.

Prepare credentials on both flows - create / destroy cluster.