### PR TITLE
Fix variable definition

### DIFF
--- a/variables
+++ b/variables
@@ -56,7 +56,7 @@ export SUBMARINER_IPSEC_NATT_PORT=4505
 export SUBMARINER_CABLE_DRIVER="libreswan"
 export SUBMARINER_GATEWAY_COUNT=1
 # The default catalog source is - redhat-operators
-export DOWNSTREAM_CATALOG_SOURCE ="submariner-catalog"
+export DOWNSTREAM_CATALOG_SOURCE="submariner-catalog"
 # When set to true, the deployment will set 2 gateways
 # on first cluster and 1 gateway on other clusters
 # Used by the testing pipeline


### PR DESCRIPTION
Definition of bash variable should be done without spaces between key and value.