### PR TITLE
Fix cypress verification test crash

### DIFF
--- a/cypress/cypress/views/submariner/actions/submariner_actions.js
+++ b/cypress/cypress/views/submariner/actions/submariner_actions.js
@@ -51,7 +51,7 @@ export const submarinerClusterSetMethods = {
     testTheDataLabel: (dataLabel, textToHave, messageToHave) => {
         cy.get(dataLabel).each(($el, index) => {
             if (index > 0){
-                cy.wrap($el).click(40, 30, { timeout: 300000, interval: 3000 }).should('have.text', textToHave, { timeout: 300000, interval: 3000 })
+                cy.wrap($el).click(40, 30).should('have.text', textToHave)
                 cy.get('.pf-c-popover__content').contains(messageToHave).should('exist').and('be.visible')
             }
         })


### PR DESCRIPTION
Last change added to the "testTheDataLabel" function and used within "submariner_deployment_validation" test adds big timeout to command. It cause the test to crash during the execution and thrown out with "Unautorized" error.

Reverting the change of this last to the previous state.