### PR TITLE
Prevent previous results report in acm-qe jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,6 +59,10 @@ pipeline {
             steps {
                 sh """
                 ./run.sh --validate-prereq --platform "${params.PLATFORM}"
+
+                # In acm-qe jenkins, logs stored in a PV, so they are persistent over jobs.
+                # Delete "logs/" dir so in case the job skipped, previous job results will not be reported.
+                rm -rf logs/
                 """
 
                 script {


### PR DESCRIPTION
In acm-qe jenkins, logs stored in a PV, so they are persistent over jobs.
Delete "logs/" dir so in case the job skipped, previous job results will not be reported.