### PR TITLE
Add Jenkinsfiles for the standalone jenkins jobs

### DIFF
--- a/jenkinsfiles/SubmarinerAgentPod.yaml
+++ b/jenkinsfiles/SubmarinerAgentPod.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    label: submariner
+spec:
+  activeDeadlineSeconds: 18000
+  containers:
+  - name: jnlp
+    image: "image-registry.openshift-image-registry.svc:5000/jenkins-csb-skynet/qe-jenkins-agent:latest"
+    workingDir: '/home/jenkins'
+    env:
+      - name: HOME
+        value: '/home/jenkins'
+    resources:
+      limits:
+        cpu: 100m
+        memory: 300Mi
+      requests:
+        cpu: 50m
+        memory: 256Mi
+  - name: submariner
+    image: 'quay.io/maxbab/subm-test:test'
+    # imagePullSecrets: 'agent-image-secret'
+    ttyEnabled: true
+    alwaysPullImage: true
+    command: [ 'sleep', '365d' ]
+    workingDir: '/home/jenkins'
+    env:
+      - name: HOME
+        value: '/home/jenkins'
+    resources:
+      limits:
+        cpu: 2000m
+        memory: 3Gi
+      requests:
+        cpu: 2000m
+        memory: 3Gi

--- a/jenkinsfiles/aws-gcp-azure.Jenkinsfile
+++ b/jenkinsfiles/aws-gcp-azure.Jenkinsfile
@@ -1,0 +1,20 @@
+podTemplate(yaml: readTrusted('jenkinsfiles/SubmarinerAgentPod.yaml')) {
+    node(POD_LABEL) {
+        checkout scm
+
+        properties([
+            parameters([
+                extendedChoice(name: 'JOB_STAGES', description: 'Select the stages of the job to be executed',
+                    value: 'Deploy OCP cluster,Deploy ACM Hub,Deploy Clusters by ACM,Submariner Validate prerequisites,Submariner Deploy,Submariner Test - API,Submariner Test - UI,Report to Polarion',
+                    defaultValue: 'Deploy OCP cluster,Deploy ACM Hub,Deploy Clusters by ACM,Submariner Validate prerequisites,Submariner Deploy,Submariner Test - API,Submariner Test - UI,Report to Polarion',
+                    multiSelectDelimiter: ',', type: 'PT_CHECKBOX', visibleItemCount: 10),
+                credentials(name: 'SUBMARINER_CONFIG', defaultValue: 'acm-2.8-subm-0.15-aws-gcp-azure', description: 'Submariner config for environment deploy',
+                    required: true, credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.FileCredentialsImpl')
+            ])
+        ])
+
+        container('submariner') {
+            load 'jenkinsfiles/base.Jenkinsfile'
+        }
+    }
+}

--- a/jenkinsfiles/base.Jenkinsfile
+++ b/jenkinsfiles/base.Jenkinsfile
@@ -1,0 +1,266 @@
+pipeline {
+    agent none
+    // Agent definition is not used here as it's defined
+    // by the jenkinsfile that loads this file.
+    // agent {
+    //     kubernetes {
+    //         defaultContainer 'submariner'
+    //         yamlFile 'jenkinsfiles/SubmarinerAgentPod.yaml'
+    //     }
+    // }
+    options {
+        ansiColor('xterm')
+        buildDiscarder(logRotator(daysToKeepStr: '30'))
+        timeout(time: 8, unit: 'HOURS')
+    }
+    parameters {
+        string(name: 'OC_CLUSTER_URL', defaultValue: '', description: 'ACM Hub API URL')
+        string(name: 'OC_CLUSTER_USER', defaultValue: '', description: 'ACM Hub username')
+        string(name: 'OC_CLUSTER_PASS', defaultValue: '', description: 'ACM Hub password')
+        extendedChoice(name: 'PLATFORM', description: 'The managed clusters platform that should be tested',
+            value: 'aws,gcp,azure,vsphere', defaultValue: 'aws,gcp,azure,vsphere', multiSelectDelimiter: ',', type: 'PT_CHECKBOX')
+        booleanParam(name: 'GLOBALNET', defaultValue: true, description: 'Deploy Globalnet on Submariner')
+        booleanParam(name: 'DOWNSTREAM', defaultValue: true, description: 'Deploy downstream version of Submariner')
+        booleanParam(name: 'SUBMARINER_GATEWAY_RANDOM', defaultValue: true, description: 'Deploy two submariner gateways on one of the clusters')
+    }
+    environment {
+        // Parameter will be used to disable globalnet in
+        // ACM version below 2.5.0 as it's not supported
+        GLOBALNET_TRIGGER = true
+        // The secret contains polarion authentication
+        // and other details for report publish
+        POLARION_SECRET = credentials('submariner-polarion-secret')
+        SUBMARINER_CONF = credentials('SUBMARINER_CONFIG')
+    }
+    stages {
+        // Environment vars defined within "environment" block
+        // could not be overriden to be used across stages sh block.
+        // Current flow could get OC_CLUSTER... var as parameter defined
+        // by the user at job trigger or be defined later after cluster creation.
+        // In order to be defined later and be able to override the env var,
+        // we use init of env vars within stage.
+        stage('Init env params') {
+            steps {
+                script {
+                    if (params.OC_CLUSTER_URL != '' &&
+                        params.OC_CLUSTER_USER != '' &&
+                        params.OC_CLUSTER_PASS != '') {
+                            env.OC_CLUSTER_URL = params.OC_CLUSTER_URL
+                            env.OC_CLUSTER_USER = params.OC_CLUSTER_USER
+                            env.OC_CLUSTER_PASS = params.OC_CLUSTER_PASS
+                    }
+                }
+            }
+        }
+        stage('Deploy OCP cluster') {
+            when {
+                expression {
+                    params.JOB_STAGES.contains(STAGE_NAME)
+                }
+            }
+            steps {
+                script {
+                    if (env.OC_CLUSTER_URL == '' &&
+                        env.OC_CLUSTER_USER == '' &&
+                        env.OC_CLUSTER_PASS == '') {
+                            println "OCP cluster deploy"
+                            sh """
+                            ansible-playbook -v playbooks/ocp.yml -e @"${SUBMARINER_CONF}"
+                            """
+
+                            env.OC_CLUSTER_URL = sh(
+                                script: "yq eval '.[].api' logs/ocp_assets/clusters_details.yml | head -1",
+                                returnStdout: true).trim()
+                            env.OC_CLUSTER_PASS = sh(
+                                script: "yq eval '.[].pass' logs/ocp_assets/clusters_details.yml | head -1",
+                                returnStdout: true).trim()
+                            env.OC_CLUSTER_USER = "kubeadmin"
+                    } else {
+                        println "OCP cluster details has been provided externally. Skipping creation..."
+                    }
+                }
+            }
+        }
+        stage('Deploy ACM Hub') {
+            when {
+                expression {
+                    params.JOB_STAGES.contains(STAGE_NAME)
+                }
+            }
+            steps {
+                sh """
+                ansible-playbook -v playbooks/acm.yml -e @"${SUBMARINER_CONF}"
+                """
+            }
+        }
+        stage('Deploy Clusters by ACM') {
+            when {
+                expression {
+                    params.JOB_STAGES.contains(STAGE_NAME)
+                }
+            }
+            steps {
+                sh """
+                ansible-playbook -v playbooks/managed_cluster.yml -e @"${SUBMARINER_CONF}"
+                """
+            }
+        }
+        // This stage will validate the environment for the job.
+        // If the prerequisites will not met, the job will not be
+        // executed to avoid non submariner job failures.
+        stage('Submariner Validate prerequisites') {
+            when {
+                expression {
+                    params.JOB_STAGES.contains(STAGE_NAME)
+                }
+            }
+            steps {
+                sh """
+                ./run.sh --validate-prereq --platform "${params.PLATFORM}"
+                """
+
+                script {
+                    def state = readFile(file: 'validation_state.log')
+                    println(state)
+                    // If validation_state.log file contains string "Not ready!",
+                    // meaning environment prerequisites are not ready.
+                    // The job will not be executed.
+                    if (state.contains('Not ready!')) {
+                        EXECUTE_JOB = false
+                        currentBuild.result = 'NOT_BUILT'
+                    } else {
+                        EXECUTE_JOB = true
+                    }
+
+                    def mch_ver = readFile(file: 'mch_version.log')
+                    println("MultiClusterHub version: " + mch_ver)
+                    mch_ver_major = mch_ver.split('\\.')[0] as Integer
+                    mch_ver_minor = mch_ver.split('\\.')[1] as Integer
+
+                    // Checks the version of the MultiClusterHub
+                    // If the version is below 2.5.0, globalnet
+                    // is not supported - disable it.
+                    // Otherwise, use parameter definition.
+                    globalnet_ver = '2.5'
+                    globalnet_ver_major = globalnet_ver.split('\\.')[0] as Integer
+                    globalnet_ver_minor = globalnet_ver.split('\\.')[1] as Integer
+                    if (mch_ver_major < globalnet_ver_major ||
+                        mch_ver_minor < globalnet_ver_minor) {
+                            println("Disable Globalnet as it's not supported in ACM " + mch_ver)
+                            GLOBALNET_TRIGGER = false
+                        }
+                }
+            }
+        }
+        stage('Submariner Deploy') {
+            when {
+                allOf {
+                    expression {
+                        params.JOB_STAGES.contains(STAGE_NAME)
+                    }
+                    expression {
+                        EXECUTE_JOB == true
+                    }
+                }
+            }
+            steps {
+                script {
+                    GLOBALNET = "--globalnet ${params.GLOBALNET}"
+                    // The "GLOBALNET_TRIGGER" will be used as a
+                    // control point to for ACM versions below 2.5.0
+                    // As it's not supported.
+                    if (GLOBALNET_TRIGGER.toBoolean() == false) {
+                        GLOBALNET = "--globalnet false"
+                    }
+
+                    DOWNSTREAM = "--downstream false"
+                    if (params.DOWNSTREAM) {
+                        DOWNSTREAM = "--downstream true"
+                    }
+
+                    // Deploy two submariner gateways on one of the clusters
+                    // to test submariner gateway fail-over scenario.
+                    SUBMARINER_GATEWAY_RANDOM = "--subm-gateway-random false"
+                    if (params.SUBMARINER_GATEWAY_RANDOM) {
+                        SUBMARINER_GATEWAY_RANDOM = "--subm-gateway-random true"
+                    }
+                }
+
+                sh """
+                ./run.sh --deploy --platform "${params.PLATFORM}" $GLOBALNET $DOWNSTREAM $SUBMARINER_GATEWAY_RANDOM
+                """
+            }
+        }
+        stage('Submariner Test - API') {
+            when {
+                allOf {
+                    expression {
+                        params.JOB_STAGES.contains(STAGE_NAME)
+                    }
+                    expression {
+                        EXECUTE_JOB == true
+                    }
+                }
+            }
+            steps {
+                script {
+                    DOWNSTREAM = "--downstream false"
+                    if (params.DOWNSTREAM) {
+                        DOWNSTREAM = "--downstream true"
+                    }
+                }
+
+                sh """
+                ./run.sh --test --test-type e2e --platform "${params.PLATFORM}" $DOWNSTREAM
+                """
+            }
+        }
+        stage('Submariner Test - UI') {
+            when {
+                allOf {
+                    expression {
+                        params.JOB_STAGES.contains(STAGE_NAME)
+                    }
+                    expression {
+                        EXECUTE_JOB == true
+                    }
+                }
+            }
+            steps {
+                script {
+                    DOWNSTREAM = "--downstream false"
+                    if (params.DOWNSTREAM) {
+                        DOWNSTREAM = "--downstream true"
+                    }
+                }
+
+                sh """
+                ./run.sh --test --test-type ui --platform "${params.PLATFORM}" $DOWNSTREAM
+                """
+            }
+        }
+        stage('Report to Polarion') {
+            when {
+                allOf {
+                    expression {
+                        params.JOB_STAGES.contains(STAGE_NAME)
+                    }
+                    expression {
+                        EXECUTE_JOB == true
+                    }
+                }
+            }
+            steps {
+                sh """
+                ./run.sh --report --polarion-vars-file "${POLARION_SECRET}"
+                """
+            }
+        }
+    }
+    post {
+        always {
+            archiveArtifacts artifacts: "logs/**", followSymlinks: false, allowEmptyArchive: true
+            junit allowEmptyResults: true, testResults: "logs/**/**/*junit.xml"
+        }
+    }
+}

--- a/jenkinsfiles/env-destroy.Jenkinsfile
+++ b/jenkinsfiles/env-destroy.Jenkinsfile
@@ -1,0 +1,48 @@
+pipeline {
+    agent {
+        kubernetes {
+            defaultContainer 'submariner'
+            yamlFile 'jenkinsfiles/SubmarinerAgentPod.yaml'
+        }
+    }
+    options {
+        ansiColor('xterm')
+        buildDiscarder(logRotator(daysToKeepStr: '30'))
+        timeout(time: 8, unit: 'HOURS')
+    }
+    parameters {
+        string(name: 'JOB_NAME', defaultValue: 'Custom-Env-Build', description: 'Job name')
+        string(name: 'BUILD_NUMBER', defaultValue: '', description: 'Build number of the job')
+        credentials(name: 'SUBMARINER_CONFIG', defaultValue: '', description: 'Submariner config for environment deploy',
+            required: true, credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.FileCredentialsImpl')
+    }
+    environment {
+        SUBMARINER_CONF = credentials('SUBMARINER_CONFIG')
+    }
+    stages {
+        stage('Fetch ACM Hub assets') {
+            steps {
+                script {
+                    try {
+                        step ([$class: 'CopyArtifact',
+                            projectName: "${JOB_NAME}",
+                            selector: specific("${BUILD_NUMBER}"),
+                            filter: "logs/",
+                            flatten: false]);
+                    }
+                    catch (exc) {
+                        echo 'Failed to fetch config for the specified job'
+                        throw new Exception("Job cannot continue without config information from deployment pipeline")
+                    }
+                }
+            }
+        }
+        stage('Destroy environment') {
+            steps {
+                sh """
+                ansible-playbook -v playbooks/env_destroy.yml -e @"${SUBMARINER_CONF}"
+                """
+            }
+        }
+    }
+}

--- a/jenkinsfiles/gcp-vsphere.Jenkinsfile
+++ b/jenkinsfiles/gcp-vsphere.Jenkinsfile
@@ -1,0 +1,20 @@
+podTemplate(yaml: readTrusted('jenkinsfiles/SubmarinerAgentPod.yaml')) {
+    node(POD_LABEL) {
+        checkout scm
+
+        properties([
+            parameters([
+                extendedChoice(name: 'JOB_STAGES', description: 'Select the stages of the job to be executed',
+                    value: 'Deploy OCP cluster,Deploy ACM Hub,Deploy Clusters by ACM,Submariner Validate prerequisites,Submariner Deploy,Submariner Test - API,Submariner Test - UI,Report to Polarion',
+                    defaultValue: 'Deploy OCP cluster,Deploy ACM Hub,Deploy Clusters by ACM,Submariner Validate prerequisites,Submariner Deploy,Submariner Test - API,Submariner Test - UI,Report to Polarion',
+                    multiSelectDelimiter: ',', type: 'PT_CHECKBOX', visibleItemCount: 10),
+                credentials(name: 'SUBMARINER_CONFIG', defaultValue: 'acm-2.8-subm-0.15-gcp-vsphere', description: 'Submariner config for environment deploy',
+                    required: true, credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.FileCredentialsImpl')
+            ])
+        ])
+
+        container('submariner') {
+            load 'jenkinsfiles/base.Jenkinsfile'
+        }
+    }
+}


### PR DESCRIPTION
- Add base.Jenkinsfile file that contains all stages being reused by other jenkinsfiles.
- Add aws-gcp-azure.Jenkinsfile and gcp-vsphere.Jenkinsfile jobs that will use the base file as source while applying specific job related parameters.
- Add env-destroy.Jenkinsfile job that will destroy the given environment.
- Add SubmarinerAgentPod.yaml to set the templates for the pod that an agent will use while spawned by the jenkins during job execution.