### PR TITLE
Fix ROSA binary in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN dnf install --nodocs -y \
 
 RUN wget -qO- "$OCP_CLI" | tar zxv -C /usr/local/bin/ oc kubectl \
     && wget -qO- "$YQ" -O /usr/local/bin/yq && chmod +x /usr/local/bin/yq \
-    && wget -qO- "$ROSA_CLI" | tar zxv -C /usr/local/bin/ rosa \
+    && wget -qO- "$ROSA_CLI" | tar zxv --no-same-owner -C /usr/local/bin/ rosa \
     && curl "$AWS_CLI" -o aws.zip && unzip aws.zip && ./aws/install && rm -rf aws*
 
 COPY requirements.txt requirements.yml ./


### PR DESCRIPTION
When building container image with podman runtime, it fails when fetching rosa binary and placing it under "/usr/local/bin/". The ownership sets to a random UID and GID which cause build proccess to fail.

Fix it by adding "--no-same-owner" flag to tar command.