### PR TITLE
Fix log file search path

### DIFF
--- a/lib/submariner_test/submariner_test.sh
+++ b/lib/submariner_test/submariner_test.sh
@@ -105,7 +105,7 @@ function get_tests_failures() {
     local diagnose_logs
     local e2e_tests_log
 
-    for log in "$TESTS_LOGS"/*.log; do
+    for log in "$TESTS_LOGS"/**/*.log; do
         diagnose_logs=$(grep --no-messages '✗' "$log" || true)
         if [[ -n "$diagnose_logs" ]]; then
             echo


### PR DESCRIPTION
The "get_tests_failures" function search for the errors through the log files created during test execution.
Fix the path to search in the proper location.