### PR TITLE
[OCP role] - Print clusters details as summary

### DIFF
--- a/roles/ocp/tasks/fetch_details.yml
+++ b/roles/ocp/tasks/fetch_details.yml
@@ -44,12 +44,12 @@
     create: true
     state: present
 
-- name: Print "{{ item.name }}" cluster details
+- name: Add cluster details to the state message
   vars:
     msg: |
       Deployment of {{ item.name }} cluster succeeded.
 
       Cluster connection details could be found here: {{ working_path }}/{{ clusters_details_file }}
       Cluster manifests files could be found here: {{ working_path }}/{{ item.name }}/
-  ansible.builtin.debug:
-    msg: "{{ msg.split('\n') }}"
+  ansible.builtin.set_fact:
+    cl_state: "{{ cl_state | default([]) + msg.split('\n') }}"

--- a/roles/ocp/tasks/main.yml
+++ b/roles/ocp/tasks/main.yml
@@ -82,8 +82,13 @@
         - cl_file_state.stat.size == 0
   when: state == "absent"
 
-- name: Fetch OCP cluster details
-  ansible.builtin.include_tasks:
-    file: fetch_details.yml
-  loop: "{{ clusters }}"
+- block:
+    - name: Fetch OCP cluster details
+      ansible.builtin.include_tasks:
+        file: fetch_details.yml
+      loop: "{{ clusters }}"
+
+    - name: Print clusters details
+      ansible.builtin.debug:
+        msg: "{{ cl_state }}"
   when: state == "present"


### PR DESCRIPTION
Print all deployed clusters details as summary at the end of role execution to keep the information for the clusters in one print.