### PR TITLE
Change OC_CLUSTER_URL environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The execution of the flow is done by providing a main argument followed by an op
 Example:
 
 ```bash
-export OC_CLUSTER_URL=<hub cluster url>
+export OC_CLUSTER_API=<hub cluster api url>
 export OC_CLUSTER_USER=<cluster user name (kubeadmin)>
 export OC_CLUSTER_PASS=<password of the cluster user>
 

--- a/lib/common/helper_functions.sh
+++ b/lib/common/helper_functions.sh
@@ -50,7 +50,7 @@ function usage() {
             to set submariner configurations.
 
     Export the following values to execute the flow:
-    export OC_CLUSTER_URL=<hub cluster url>
+    export OC_CLUSTER_API=<hub cluster url>
     export OC_CLUSTER_USER=<cluster user name>
     export OC_CLUSTER_PASS=<password of the cluster user>
 
@@ -177,7 +177,7 @@ function login_to_cluster() {
 
     if [[ "$cluster" == "hub" ]]; then
         oc login --insecure-skip-tls-verify \
-            -u "$OC_CLUSTER_USER" -p "$OC_CLUSTER_PASS" "$OC_CLUSTER_URL"
+            -u "$OC_CLUSTER_USER" -p "$OC_CLUSTER_PASS" "$OC_CLUSTER_API"
         oc cluster-info | grep Kubernetes
     else
         if [[ ! -f "$KCONF/$cluster-password" || ! -f "$KCONF/$cluster-kubeconfig.yaml" ]]; then

--- a/run.sh
+++ b/run.sh
@@ -35,12 +35,12 @@ source "${SCRIPT_DIR}/lib/reporting/polarion.sh"
 
 
 function verify_required_env_vars() {
-    if [[ -z "${OC_CLUSTER_USER}" || -z "${OC_CLUSTER_PASS}" || -z "${OC_CLUSTER_URL}" ]]; then
+    if [[ -z "${OC_CLUSTER_USER}" || -z "${OC_CLUSTER_PASS}" || -z "${OC_CLUSTER_API}" ]]; then
         if [[ "$RUN_COMMAND" == "validate-prereq" ]]; then
             VALIDATION_STATE+="Not ready! Missing environment vars. Unable to login to the hub."
         else
             ERROR "Execution of the script require all env variables provided:
-            'OC_CLUSTER_USER', 'OC_CLUSTER_PASS', 'OC_CLUSTER_URL'"
+            'OC_CLUSTER_USER', 'OC_CLUSTER_PASS', 'OC_CLUSTER_API'"
         fi
     fi
     if [[ "$PLATFORM" =~ "rosa" ]]; then


### PR DESCRIPTION
Submariner deployment/test flow uses three main environment variables as part of the flow.
One of the environment variables is - OC_CLUSTER_URL. The name of missleading, since actually, the variable expect to get the openshift cluster api url.

Rename the OC_CLUSTER_URL to OC_CLUSTER_API variable to prevent future missleading.