### PR TITLE
Modify ansible collection requirements

### DIFF
--- a/playbooks/acm.yml
+++ b/playbooks/acm.yml
@@ -2,5 +2,7 @@
 - name: Advanced Cluster Mnagement Hub
   hosts: localhost
   gather_facts: false
+  collections:
+    - stolostron.rhacm
   roles:
     - acm

--- a/playbooks/env_deploy.yml
+++ b/playbooks/env_deploy.yml
@@ -3,6 +3,8 @@
   gather_facts: false
   vars:
     state: present
+  collections:
+    - stolostron.rhacm
   roles:
     - ocp
     - acm

--- a/playbooks/env_destroy.yml
+++ b/playbooks/env_destroy.yml
@@ -3,6 +3,8 @@
   gather_facts: false
   vars:
     state: absent
+  collections:
+    - stolostron.rhacm
   roles:
     - managed_cluster
     - ocp

--- a/playbooks/managed_cluster.yml
+++ b/playbooks/managed_cluster.yml
@@ -2,5 +2,7 @@
 - name: Managed Clusters
   hosts: localhost
   gather_facts: false
+  collections:
+    - stolostron.rhacm
   roles:
     - managed_cluster

--- a/playbooks/ocp.yml
+++ b/playbooks/ocp.yml
@@ -2,5 +2,7 @@
 - name: OpenShift cluster
   hosts: localhost
   gather_facts: false
+  collections:
+    - stolostron.rhacm
   roles:
     - ocp

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,6 +1,5 @@
 ---
 collections:
-  - name: kubernetes.core
-    version: 2.4.0
-  - name: community.okd
-    version: 2.3.0
+  - name: https://github.com/stolostron/ansible-collection.rhacm.git
+    type: git
+    version: main


### PR DESCRIPTION
Ansible roles responsible for deploying ACM based environment moved to a collection [1].
Update ansible requirements to fetch the collection. Update the playbooks to get the roles according to collection.

[1] - https://github.com/stolostron/ansible-collection.rhacm