### PR TITLE
Add --subm-catalog-update flag to run.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ export OC_CLUSTER_PASS=<password of the cluster user>
 
     --test                 - Perform testing of the Submariner addon
 
+    --subm-catalog-update  - Perform update of the Submariner's catalog source
+
     --report               - Report tests results to Polarion
 
     --gather-logs          - Gather debug info and logs for environment

--- a/run.sh
+++ b/run.sh
@@ -135,6 +135,11 @@ function report() {
     report_polarion
 }
 
+function update_submariner_catalog() {
+    select_submariner_version_and_channel_to_deploy
+    update_catalog_source
+}
+
 function finalize() {
     if [[ "$TESTS_FAILURES" == "true" ]]; then
         WARNING "Tests execution contains failures"
@@ -155,6 +160,10 @@ function parse_arguments() {
                 ;;
             --deploy)
                 RUN_COMMAND="deploy"
+                shift
+                ;;
+            --subm-catalog-update)
+                RUN_COMMAND="catalog-update"
                 shift
                 ;;
             --test)
@@ -279,6 +288,11 @@ function main() {
         deploy)
             prepare
             deploy_submariner
+            finalize
+            ;;
+        catalog-update)
+            prepare
+            update_submariner_catalog
             finalize
             ;;
         test)


### PR DESCRIPTION
- Add a function that update the submariner catalog source on managed clusters
- Add --subm-catalog-update flag to the the run.sh
- Add this argument to the documentation