### PR TITLE
Add cypress browser selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,12 @@ export OC_CLUSTER_PASS=<password of the cluster user>
                              (Optional)
                              By default - e2e,ui
 
+    --test-browser         - Select the browser to be used during UI testing.
+                             - chrome
+                             - electron
+                             (Optional)
+                             By default - chrome
+
     --report-suffix        - Add suffix to the tests basename.
                              (Optional)
                              By default - empty string

--- a/jenkinsfiles/acm-qe.Jenkinsfile
+++ b/jenkinsfiles/acm-qe.Jenkinsfile
@@ -22,6 +22,7 @@ pipeline {
         booleanParam(name: 'DOWNSTREAM', defaultValue: true, description: 'Deploy downstream version of Submariner')
         booleanParam(name: 'SUBMARINER_GATEWAY_RANDOM', defaultValue: true, description: 'Deploy two submariner gateways on one of the clusters')
         string(name:'TEST_TAGS', defaultValue: '', description: 'A tag to control job execution')
+        string(name: 'BROWSER', defaultValue: '', description: 'Specify the browser for cypress testing (by default uses chrome)')
         booleanParam(name: 'POLARION', defaultValue: true, description: 'Publish tests results to Polarion')
         choice(name: 'JOB_STAGES', choices: ['all', 'deploy', 'test'], description: 'Select stage that should be executed by the job')
     }
@@ -191,6 +192,11 @@ pipeline {
                             TESTS_TYPE = "--test-type e2e"
                         }
 
+                    TEST_BROWSER = ""
+                    if (params.BROWSER != '') {
+                        TEST_BROWSER = "--test-browser ${params.BROWSER}"
+                    }
+
                     REPORT_SUFFIX = ""
                     if (params.TEST_TAGS == '@post-restore') {
                         REPORT_SUFFIX = "--report-suffix backup-restore"
@@ -198,7 +204,7 @@ pipeline {
                 }
 
                 sh """
-                ./run.sh --test --platform "${params.PLATFORM}" $DOWNSTREAM $TESTS_TYPE $REPORT_SUFFIX
+                ./run.sh --test --platform "${params.PLATFORM}" $DOWNSTREAM $TESTS_TYPE $TEST_BROWSER $REPORT_SUFFIX
                 """
             }
         }

--- a/lib/common/helper_functions.sh
+++ b/lib/common/helper_functions.sh
@@ -104,6 +104,12 @@ function usage() {
                              (Optional)
                              By default - e2e,ui
 
+    --test-browser         - Select the browser to be used during UI testing.
+                             - chrome
+                             - electron
+                             (Optional)
+                             By default - chrome
+
     --report-suffix        - Add suffix to the tests basename.
                              (Optional)
                              By default - empty string

--- a/lib/submariner_test/submariner_ui.sh
+++ b/lib/submariner_test/submariner_ui.sh
@@ -25,7 +25,7 @@ function execute_submariner_ui_tests() {
     export CYPRESS_CLUSTERSET="$CLUSTERSET"
     export CYPRESS_SUBMARINER_IPSEC_NATT_PORT="$SUBMARINER_IPSEC_NATT_PORT"
 
-    npx cypress run --browser chrome --headless --env grepFilterSpecs=true,grepTags=@e2e || true
+    npx cypress run --browser "$TEST_BROWSER" --headless --env grepFilterSpecs=true,grepTags=@e2e || true
 
     INFO "Combine cypress reports"
     npx jrm "$TESTS_LOGS_UI/${tests_basename}_junit.xml" results/test-results-*.xml

--- a/run.sh
+++ b/run.sh
@@ -210,6 +210,12 @@ function parse_arguments() {
                     shift 2
                 fi
                 ;;
+            --test-browser)
+                if [[ -n "$2" ]]; then
+                    export TEST_BROWSER="$2"
+                    shift 2
+                fi
+                ;;
             --report-suffix)
                 if [[ -n "$2" ]]; then
                     export TEST_REPORT_SUFFIX="$2"

--- a/variables
+++ b/variables
@@ -87,6 +87,9 @@ export LATEST_IIB=""
 # Test type that should be executed.
 # e2e (api testing), ui (cypress testing)
 export TEST_TYPE="e2e,ui"
+# Define the browser to be used for UI testing
+# chrome, electron
+export TEST_BROWSER="chrome"
 # Execute or skip UI tests. By default, execute.
 export UI_TESTS="true"
 


### PR DESCRIPTION
By default cypress executes the tests with "chrome" browser.
But it's not working when FIPS mode is enabled on the cluster.
Add "--test-browser" argument to control which browser should be used during cypress testing.

Add a "BROWSER" parameter to the acm-qe jenkins job.