### PR TITLE
[release-2.5] Adapt jenkins job

### DIFF
--- a/jenkinsfiles/SubmarinerAgentPod.yaml
+++ b/jenkinsfiles/SubmarinerAgentPod.yaml
@@ -20,7 +20,7 @@ spec:
         cpu: 50m
         memory: 256Mi
   - name: submariner
-    image: 'quay.io/maxbab/subm-test:test'
+    image: 'quay.io/maxbab/subm-test@sha256:424f3672eb1f01e3d0abb36dd21b425fffbb255500c812fa35ed869c44446b78'
     # imagePullSecrets: 'agent-image-secret'
     ttyEnabled: true
     alwaysPullImage: true

--- a/jenkinsfiles/aws-gcp-azure.Jenkinsfile
+++ b/jenkinsfiles/aws-gcp-azure.Jenkinsfile
@@ -5,8 +5,8 @@ podTemplate(yaml: readTrusted('jenkinsfiles/SubmarinerAgentPod.yaml')) {
         properties([
             parameters([
                 extendedChoice(name: 'JOB_STAGES', description: 'Select the stages of the job to be executed',
-                    value: 'Deploy OCP cluster,Deploy ACM Hub,Deploy Clusters by ACM,Submariner Validate prerequisites,Submariner Deploy,Submariner Test - E2E,Submariner Test - Cypress UI,Report to Polarion',
-                    defaultValue: 'Deploy OCP cluster,Deploy ACM Hub,Deploy Clusters by ACM,Submariner Validate prerequisites,Submariner Deploy,Submariner Test - E2E,Submariner Test - Cypress UI,Report to Polarion',
+                    value: 'Deploy OCP cluster,Deploy ACM Hub,Deploy Clusters by ACM,Submariner Validate prerequisites,Submariner Deploy,Submariner Test - E2E,Report to Polarion',
+                    defaultValue: 'Deploy OCP cluster,Deploy ACM Hub,Deploy Clusters by ACM,Submariner Validate prerequisites,Submariner Deploy,Submariner Test - E2E,Report to Polarion',
                     multiSelectDelimiter: ',', type: 'PT_CHECKBOX', visibleItemCount: 10),
                 credentials(name: 'SUBMARINER_CONFIG', defaultValue: 'acm-2.5-subm-0.12-aws-gcp-azure', description: 'Submariner config for environment deploy',
                     required: true, credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.FileCredentialsImpl')

--- a/jenkinsfiles/base.Jenkinsfile
+++ b/jenkinsfiles/base.Jenkinsfile
@@ -21,7 +21,6 @@ pipeline {
             value: 'aws,gcp,azure,vsphere', defaultValue: 'aws,gcp,azure,vsphere', multiSelectDelimiter: ',', type: 'PT_CHECKBOX')
         booleanParam(name: 'GLOBALNET', defaultValue: true, description: 'Deploy Globalnet on Submariner')
         booleanParam(name: 'DOWNSTREAM', defaultValue: true, description: 'Deploy downstream version of Submariner')
-        booleanParam(name: 'SUBMARINER_GATEWAY_RANDOM', defaultValue: true, description: 'Deploy two submariner gateways on one of the clusters')
     }
     environment {
         // Parameter will be used to disable globalnet in
@@ -177,17 +176,10 @@ pipeline {
                     if (params.DOWNSTREAM) {
                         DOWNSTREAM = "--downstream true"
                     }
-
-                    // Deploy two submariner gateways on one of the clusters
-                    // to test submariner gateway fail-over scenario.
-                    SUBMARINER_GATEWAY_RANDOM = "--subm-gateway-random false"
-                    if (params.SUBMARINER_GATEWAY_RANDOM) {
-                        SUBMARINER_GATEWAY_RANDOM = "--subm-gateway-random true"
-                    }
                 }
 
                 sh """
-                ./run.sh --deploy --platform "${params.PLATFORM}" $GLOBALNET $DOWNSTREAM $SUBMARINER_GATEWAY_RANDOM
+                ./run.sh --deploy --platform "${params.PLATFORM}" $GLOBALNET $DOWNSTREAM
                 """
             }
         }
@@ -211,31 +203,7 @@ pipeline {
                 }
 
                 sh """
-                ./run.sh --test --test-type e2e --platform "${params.PLATFORM}" $DOWNSTREAM
-                """
-            }
-        }
-        stage('Submariner Test - Cypress UI') {
-            when {
-                allOf {
-                    expression {
-                        params.JOB_STAGES.contains(STAGE_NAME)
-                    }
-                    expression {
-                        EXECUTE_JOB == true
-                    }
-                }
-            }
-            steps {
-                script {
-                    DOWNSTREAM = "--downstream false"
-                    if (params.DOWNSTREAM) {
-                        DOWNSTREAM = "--downstream true"
-                    }
-                }
-
-                sh """
-                ./run.sh --test --test-type ui --platform "${params.PLATFORM}" $DOWNSTREAM
+                ./run.sh --test --platform "${params.PLATFORM}" $DOWNSTREAM
                 """
             }
         }


### PR DESCRIPTION
- Remove cypress UI section from the jenkinsfile as cypress UI testing
  is not imprelented in release-2.5.

- Remove the "SUBMARINER_GATEWAY_RANDOM" definition as it's not
  implemented in release-2.5.

- Set test image definition with digest instead of the tag in Submariner
  pod definition.