### PR TITLE
Fix azure-cli apply in ACM 2.5.x

### DIFF
--- a/lib/common/prerequisites.sh
+++ b/lib/common/prerequisites.sh
@@ -63,6 +63,10 @@ function verify_az_cli() {
         pip install -U requests
         pip install -U urllib3
         pip install azure-cli
+
+        # Add local BIN dir to PATH
+        [[ ":$PATH:" = *":$HOME/.local/bin:"* ]] || export PATH="$HOME/.local/bin:$PATH"
+        INFO "The azure-cli command installed"
     fi
     INFO "The az command is found"
 }

--- a/lib/submariner_prepare/azure_prepare.sh
+++ b/lib/submariner_prepare/azure_prepare.sh
@@ -79,7 +79,7 @@ function fetch_resource_group_name() {
 function label_worker_for_gateway() {
     INFO "Azure: Select and label worker as a gateway node"
     local cluster="$1"
-    local kube_conf="$LOGS/$cluster-kubeconfig.yaml"
+    local kube_conf="$KCONF/$cluster-kubeconfig.yaml"
 
     AZURE_GW_NODE=$(KUBECONFIG="$kube_conf" oc get nodes \
                      --selector "node-role.kubernetes.io/worker" \


### PR DESCRIPTION
- In ACM 2.5.x, azure cli nneds to be installed in order to manually set the prerequisites.
  Now, as moving to an containerized image, after azure-cli has been installed, add the "az" binary to the PATH.

- Fix the kubeconfig reference in azure gateway node prepare.