### PR TITLE
Update ansible collection install in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,10 +44,10 @@ RUN wget -qO- "$OCP_CLI" | tar zxv -C /usr/local/bin/ oc kubectl \
 
 COPY requirements.txt requirements.yml ./
 
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt \
+    && mkdir -p /usr/share/ansible/collections \
+    && ansible-galaxy collection install --no-cache -r requirements.yml -p /usr/share/ansible/collections
 
 USER "$SUBM"
-
-RUN ansible-galaxy collection install --no-cache -r requirements.yml
 
 WORKDIR /"$SUBM"


### PR DESCRIPTION
The image built from the Dockerfile used by two different jenkins and by local execution flow.
As a result, different user could be used during creation of the container.
In order to satisfy all the users and make ansible stolostron.rhacm collection available by all users, place it in a path that would be accessible by everyone.