### PR TITLE
Remove channel from SubmarinerConfig subscription (#433)

### DIFF
--- a/lib/submariner_deploy/submariner_deploy.sh
+++ b/lib/submariner_deploy/submariner_deploy.sh
@@ -7,11 +7,8 @@
 function prepare_clusters_for_submariner() {
     INFO "Perform Submariner cloud prepare for the managed clusters"
     local creds
-    local submariner_channel
     local catalog_ns="openshift-marketplace"
     local catalog_source="redhat-operators"
-
-    submariner_channel="$SUBMARINER_CHANNEL_RELEASE-$(echo "$SUBMARINER_VERSION_INSTALL" | grep -Po '.*(?=\.)')"
 
     if [[ "$DOWNSTREAM" == 'true' ]]; then
         catalog_source="submariner-catalog"
@@ -27,14 +24,13 @@ function prepare_clusters_for_submariner() {
         INFO "Apply SubmarinerConfig on cluster $cluster"
         INFO "Use $SUBMARINER_GATEWAY_COUNT gateway node for $cluster cluster"
 
-        CL="$cluster" CRED="$creds" SUBM_CHAN="$submariner_channel" \
+        CL="$cluster" CRED="$creds" \
             NS="$catalog_ns" SUBM_SOURCE="$catalog_source" \
             yq eval '.metadata.namespace = env(CL)
             | .spec.credentialsSecret.name = env(CRED)
             | .spec.IPSecNATTPort = env(SUBMARINER_IPSEC_NATT_PORT)
             | .spec.cableDriver = env(SUBMARINER_CABLE_DRIVER)
             | .spec.gatewayConfig.gateways = env(SUBMARINER_GATEWAY_COUNT)
-            | .spec.subscriptionConfig.channel = env(SUBM_CHAN)
             | .spec.subscriptionConfig.source = env(SUBM_SOURCE)
             | .spec.subscriptionConfig.sourceNamespace = env(NS)' \
             "$SCRIPT_DIR/manifests/submariner-config.yaml" | oc apply -f -

--- a/manifests/submariner-config.yaml
+++ b/manifests/submariner-config.yaml
@@ -13,6 +13,5 @@ spec:
   credentialsSecret:
     name: $MANAGED_CLUSTER_PLATFORM_SECRET
   subscriptionConfig:
-    channel: $SUBMARINER_CHANNEL
     source: $SUBMARINER_SOURCE
     sourceNamespace: openshift-marketplace


### PR DESCRIPTION
The channel version for submariner deployment now identified automativally by the submariner-addon.
As result, no need to specify the channel manually.

One more reason to remove definition of the channel from the SubmarinerConfig subscription section, is the ability to perform upgrade flow automatically.

(cherry picked from commit 0bad72b7de5b28666f1374adf219e902b413ee05)