### PR TITLE
Make cluster passwork fetch optional

### DIFF
--- a/lib/common/helper_functions.sh
+++ b/lib/common/helper_functions.sh
@@ -277,9 +277,14 @@ function fetch_kubeconfig_contexts_and_pass() {
             | .users[].name = env(CL)' "$KCONF/$cluster-kubeconfig.yaml"
 
         pass_name=$(oc get -n "$cluster" secrets --no-headers \
-                      -o custom-columns=NAME:.metadata.name | grep password)
-        oc get secrets "$pass_name" -n "$cluster" \
-            --template='{{index .data.password | base64decode}}' > "$KCONF/$cluster-password"
+                      -o custom-columns=NAME:.metadata.name | grep password || true)
+
+        if [[ "$pass_name" == "" ]]; then
+            WARNING "Unable to fetch admin password from $cluster cluster. Continue as not required..."
+        else
+            oc get secrets "$pass_name" -n "$cluster" \
+                --template='{{index .data.password | base64decode}}' > "$KCONF/$cluster-password"
+        fi
     done
 }
 


### PR DESCRIPTION
As a prerequisites of submariner deploy or test, a few steps needs to be done.
One of the steps, is to fetch the "kubeconfig" file and kubeadmin password value.
Some of the clusters might be missing the cluster kubeadmin password. Make the fetch of the password optional.
Only kubeconfig file will be mandatory.