### PR TITLE
Update ImageContentSourcePolicy manifest

### DIFF
--- a/manifests/image-content-source-policy.yaml
+++ b/manifests/image-content-source-policy.yaml
@@ -6,7 +6,7 @@ spec:
   repositoryDigestMirrors:
   - mirrors:
     - "$BREW_REGISTRY"
-    source: registry.redhat.io
+    source: registry.redhat.io/rhacm2
   - mirrors:
     - "$BREW_REGISTRY"
     source: registry.stage.redhat.io


### PR DESCRIPTION
Recently, Openshift ROSA SME team provibited override of registry.redhat.io explicitly.
But it's allowed to override specific namespaces.

In order to allow downstream deployment of submariner on ROSA clusters and as a general deployment flow change, set the override mirror for regsitry.redhat.io to the "rhacm2" namespace.

When the image will try to fetch the image from
registry.redhat.io/rhacm2, it will be overrided by the brew internal registry.