### PR TITLE
Increasing the time of wait on for the deployment of Submariner

### DIFF
--- a/cypress/cypress/e2e/03_submariner_deploy.cy.js
+++ b/cypress/cypress/e2e/03_submariner_deploy.cy.js
@@ -10,7 +10,7 @@ import { clusterSetMethods } from '../views/clusterset/clusterset'
 import { clustersPages } from '../views/clusters/managedCluster'
 
 describe('submariner - Deployment validation', {
-    tags: ['@submariner'],
+    tags: ['@submariner', '@e2e'],
     retries: {
         runMode: 0,
         openMode: 0,
@@ -64,7 +64,7 @@ describe('submariner - Deployment validation', {
 
         cy.get('button').contains('Install').click()
 
-        cy.wait(310000)
+        cy.wait(330000)
         submarinerClusterSetMethods.testTheDataLabel('[data-label="Gateway nodes labeled"]', 'Nodes labeled', 'submariner.io/gateway')
         submarinerClusterSetMethods.testTheDataLabel('[data-label="Agent status"]', 'Healthy', 'is deployed on managed cluster')
         submarinerClusterSetMethods.testTheDataLabel('[data-label="Connection status"]', 'Healthy', 'established')


### PR DESCRIPTION
The submariner deploy test failed because the deployment took longer than the time the test waited for it to be done