### PR TITLE
Enable cypress submariner deployment test

### DIFF
--- a/cypress/cypress/e2e/03_submariner_deploy.cy.js
+++ b/cypress/cypress/e2e/03_submariner_deploy.cy.js
@@ -10,7 +10,7 @@ import { clusterSetMethods } from '../views/clusterset/clusterset'
 import { clustersPages } from '../views/clusters/managedCluster'
 
 describe('submariner - Deployment validation', {
-    tags: ['@submariner'],
+    tags: ['@submariner', '@e2e'],
     retries: {
         runMode: 0,
         openMode: 0,
@@ -64,7 +64,7 @@ describe('submariner - Deployment validation', {
 
         cy.get('button').contains('Install').click()
 
-        cy.wait(330000)
+        cy.wait(350000)
         submarinerClusterSetMethods.testTheDataLabel('[data-label="Gateway nodes labeled"]', 'Nodes labeled', 'submariner.io/gateway')
         submarinerClusterSetMethods.testTheDataLabel('[data-label="Agent status"]', 'Healthy', 'is deployed on managed cluster')
         submarinerClusterSetMethods.testTheDataLabel('[data-label="Connection status"]', 'Healthy', 'established')


### PR DESCRIPTION
- Enable cypress submariner deployment test
- In addition to the deployment timeout increase [1], increase the timeout a bit more. As tested on additonal platforms - ARO and ROSA, existing timeout is not enough.

[1] - 051e0b4f335176e24507b18eaae33ae68c671464