### PR TITLE
Add logs to cypress uninstall test

### DIFF
--- a/cypress/cypress/e2e/01_submariner_deployment_validation.cy.js
+++ b/cypress/cypress/e2e/01_submariner_deployment_validation.cy.js
@@ -22,7 +22,16 @@ describe('submariner - Deployment validation', {
     
     it('verify that a cluster set with deployment of submariner is exists.', { tags: ['verify'] }, function () {
         let clusterSetName = Cypress.env('CLUSTERSET')
-        submarinerClusterSetMethods.submarinerClusterSetShouldExist(clusterSetName)
+        submarinerClusterSetMethods.submarinerClusterSetShouldExist(clusterSetName).then(($clusterset) => {
+            if ($clusterset.text().includes(clusterSetName)) {
+                cy.log(clusterSetName + " clusteset was found")
+                cy.get('[data-label=Name]').contains(clusterSetName).click()
+                cy.get('.pf-c-nav__link').contains('Submariner add-ons').click()
+            }
+            else {
+                cy.log(clusterSetName + ' clusterset was not found')
+            }
+        })
     })
 
     it('test the Connection status label', { tags: ['Connection'] }, function () {

--- a/cypress/cypress/e2e/02_submariner_uninstall.cy.js
+++ b/cypress/cypress/e2e/02_submariner_uninstall.cy.js
@@ -5,7 +5,7 @@
 
 /// <reference types="cypress" />
 
-import { clusterSetMethods } from '../views/clusterset/clusterset'
+import { submarinerClusterSetMethods } from '../views/submariner/actions/submariner_actions'
 
 describe('submariner - uninstall validation', {
     tags: ['@submariner', '@e2e'],
@@ -24,15 +24,11 @@ describe('submariner - uninstall validation', {
     it('test the Uninstall Submariner add-ons', { tags: ['uninstall'] }, function () {
         let clusterSetName = Cypress.env('CLUSTERSET')
         // verify that a cluster set with deployment of submariner is exists.
-        clusterSetMethods.clusterSetShouldExist(clusterSetName)
-        cy.get('[data-label=Name]').contains(clusterSetName).then($value => {
-            length = $value.length
-
-            if (length != 1) this.skip()
-            else {
-                cy.get('[data-label=Name]').eq(1).click(15, 30)
+        submarinerClusterSetMethods.submarinerClusterSetShouldExist(clusterSetName).then(($clusterset) => {
+            if ($clusterset.text().includes(clusterSetName)) {
+                cy.log(clusterSetName + " was found")
+                cy.get('[data-label=Name]').contains(clusterSetName).click()
                 cy.get('.pf-c-nav__link').contains('Submariner add-ons').click()
-
                 cy.get('.pf-c-table__check > label > input').click({multiple: true}).should('be.checked')
                 cy.get('#toggle-id').click()
                 cy.get('.pf-c-dropdown__menu-item').should('be.visible').click()
@@ -45,9 +41,14 @@ describe('submariner - uninstall validation', {
                 // Some of the clouds may take more time to delete the resource.
                 // Set the final timeout to 5 minutes.
                 // If the resources still exist after the timeout, fail the test.
+                cy.log("performing submariner uninstall")
                 cy.get('[data-label="Cluster"]', {timeout: 300000}).should('not.exist')
+                cy.log("submariner uninstall was completed")
+            }   
+            else{
+                cy.log(clusterSetName + ' was not found')
             }
         })
-    }) 
+    })
 })
 

--- a/cypress/cypress/e2e/03_submariner_deploy.cy.js
+++ b/cypress/cypress/e2e/03_submariner_deploy.cy.js
@@ -30,15 +30,13 @@ describe('submariner - Deployment validation', {
         let downstream = Cypress.env('DOWNSTREAM')
 
         //check if a cluster set named submariner already exists
-        clustersPages.goToClusterSet()
-        cy.get('.pf-c-text-input-group__text-input').type(clusterSetName)
-        cy.get('[data-label=Name]').then(($clusterset) => {
+        submarinerClusterSetMethods.submarinerClusterSetShouldExist(clusterSetName).then(($clusterset) => {
             if ($clusterset.text().includes(clusterSetName)) {
-                cy.log("found")
+                cy.log(clusterSetName + " was found")
                 cy.get('[data-label=Name]').contains(clusterSetName).click()
             }
             else{
-                cy.log('not found')
+                cy.log(clusterSetName + ' was not found')
                 clusterSetMethods.createClusterSet(clusterSetName)
                 submarinerClusterSetMethods.manageClusterSet(managed_clusters_list, clusterSetName)
                 cy.get('button').contains('Save').click()
@@ -65,9 +63,9 @@ describe('submariner - Deployment validation', {
         cy.get('button').contains('Install').click()
 
         cy.wait(350000)
-        submarinerClusterSetMethods.testTheDataLabel('[data-label="Gateway nodes labeled"]', 'Nodes labeled', 'submariner.io/gateway')
-        submarinerClusterSetMethods.testTheDataLabel('[data-label="Agent status"]', 'Healthy', 'is deployed on managed cluster')
-        submarinerClusterSetMethods.testTheDataLabel('[data-label="Connection status"]', 'Healthy', 'established')
+        submarinerClusterSetMethods.testTheDataLabel("Gateway nodes labeled", 'Nodes labeled', 'submariner.io/gateway')
+        submarinerClusterSetMethods.testTheDataLabel("Agent status", 'Healthy', 'is deployed on managed cluster')
+        submarinerClusterSetMethods.testTheDataLabel("Connection status", 'Healthy', 'established')
     })
 })
 

--- a/cypress/cypress/views/clusters/managedCluster.js
+++ b/cypress/cypress/views/clusters/managedCluster.js
@@ -27,6 +27,7 @@ export const clustersPages = {
     },
 
     goToClusterSet: () => {
+        cy.log("go to cluster set page")
         acm23xheaderMethods.goToClusters()
         cy.get(commonElementSelectors.elements.pageNavLink).filter(`:contains("${managedClustersSelectors.elementTab.clustersets}")`).click()
         clusterSetPages.shouldLoad()

--- a/cypress/cypress/views/submariner/actions/submariner_actions.js
+++ b/cypress/cypress/views/submariner/actions/submariner_actions.js
@@ -6,24 +6,17 @@
 /// <reference types="cypress" />
 
 import { clusterSetMethods } from '../../../views/clusterset/clusterset'
+import { clustersPages } from '../../../views/clusters/managedCluster'
 
 export const submarinerClusterSetMethods = {
 
-    // The function verifies that submariner deployment exists.
+    // The function verifies that submariner cluster exists.
     submarinerClusterSetShouldExist: (clusterSetName) => {
-        cy.log("verify that a cluster set with deployment of submariner is exists")
-        clusterSetMethods.clusterSetShouldExist(clusterSetName)
+        cy.log("verify that a cluster set named " + clusterSetName + " exists")
+        clustersPages.goToClusterSet()
+        cy.get('.pf-c-text-input-group__text-input').type(clusterSetName)
 
-        cy.get('[data-label=Name]').eq(1).then(($clusterset) => {
-            if ($clusterset.text().includes(clusterSetName)) {
-                cy.log("A cluster set named " + clusterSetName + " was found")
-                cy.get('[data-label=Name]').contains(clusterSetName).click()
-                cy.get('.pf-c-nav__link').contains('Submariner add-ons').click()
-            }
-            else{
-                cy.log("A cluster set named " + clusterSetName + " was not found. can't continue with the test")
-            }
-        })
+        return cy.get('[data-label=Name]')
     },
 
     // The function adds the AWS an GCP clusters to the cluster set.


### PR DESCRIPTION
- Modification of the method "ClusterSetShouldExist" so that it fits many tests
-  Modification of the method "ClusterSetShouldExist"  so it will write to the logs if the cluster was found or not
- Adapting the deploy validation and deploy tests to the new form of the method
- add logs to the uninstall test