### PR TITLE
Added creation of a log file for the UI tests

### DIFF
--- a/cypress/cypress.config.js
+++ b/cypress/cypress.config.js
@@ -21,7 +21,8 @@ module.exports = defineConfig({
     SUBMARINER_IPSEC_NATT_PORT: "4505",
     DOWNSTREAM_CATALOG_SOURCE: "submariner-catalog",
     MANAGED_CLUSTERS: "",
-    DOWNSTREAM: "true"
+    DOWNSTREAM: "true",
+    LOGS_PATH: "logs"
   },
 
   e2e: {

--- a/cypress/cypress/e2e/04_submariner_addon.cy.js
+++ b/cypress/cypress/e2e/04_submariner_addon.cy.js
@@ -22,10 +22,13 @@ describe('submariner - validate submariner addon tab', {
 
     it('test the Submariner add-ons', { tags: ['addon'] }, function () {
         let clusterSetName = Cypress.env('CLUSTERSET')+'-'+(Math.random() + 1).toString(36).substring(4)
+        cy.log('create a cluster set named ' + clusterSetName)
         clusterSetMethods.createClusterSet(clusterSetName)
         cy.get('.pf-c-text-input-group__text-input').type(clusterSetName)
         cy.contains(clusterSetName).should('exist').click({timeout: 3000})
         cy.get('.pf-c-nav__link').contains('Submariner add-ons').should('exist')
+        cy.log("submariner add-ons tab was found")
+        cy.log("delete the cluster set named " + clusterSetName)
         clusterSetMethods.deleteClusterSet(clusterSetName)
     })
 })

--- a/cypress/cypress/support/e2e.js
+++ b/cypress/cypress/support/e2e.js
@@ -15,3 +15,20 @@
 
 // Import commands.js using ES2015 syntax:
 import './commands'
+
+var logs = {}
+var i = 0
+
+Cypress.on('log:added', (log) => {
+    if (log.end) {
+        logs[i] = log.message
+        i++
+    }
+})
+
+let name = Cypress.spec.name
+let path = Cypress.env('LOGS_PATH')
+
+after(() => {
+  cy.writeFile(path+'/'+name+'.log', logs)
+})

--- a/lib/submariner_test/submariner_ui.sh
+++ b/lib/submariner_test/submariner_ui.sh
@@ -25,6 +25,8 @@ function execute_submariner_ui_tests() {
     export CYPRESS_CLUSTERSET="$CLUSTERSET"
     export CYPRESS_SUBMARINER_IPSEC_NATT_PORT="$SUBMARINER_IPSEC_NATT_PORT"
 
+    export CYPRESS_LOGS_PATH="$TESTS_LOGS_UI"
+
     npx cypress run --browser "$TEST_BROWSER" --headless --env grepFilterSpecs=true,grepTags=@e2e || true
 
     INFO "Combine cypress reports"


### PR DESCRIPTION
- At the end of running each UI test, a log file will be created in /logs/ui_logs
- Add logs to submariner add on cypress test