### PR TITLE
Add private quay credentials apply on spoke clusters

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -107,7 +107,7 @@ function deploy_submariner() {
     fi
 
     if [[ "$DOWNSTREAM" == 'true' ]]; then
-        create_brew_secret
+        create_brew_and_private_quay_secret
         create_icsp
 
         create_catalog_source

--- a/variables
+++ b/variables
@@ -68,6 +68,7 @@ export OFFICIAL_REGISTRY="registry.redhat.io"
 export STAGING_REGISTRY="registry.stage.redhat.io"
 # External RedHat downstream registry (require authentication)
 export BREW_REGISTRY="brew.registry.redhat.io"
+export PRIVATE_QUAY_REGISTRY="quay.io:443"
 export REGISTRY_IMAGE_PREFIX="rhacm2"
 export REGISTRY_IMAGE_IMPORT_PATH="rh-osbs"
 # Internal RedHat downstream registry


### PR DESCRIPTION
Recently, "submariner-addon" component in ACM moved under MCE. It means that now, during submariner deployment, "submariner-addon" pod requires "quay.io:443" credentials to be able to fetch the image from the quay.io:443/acm-d private repository.

Add a flow to copy the quay.io:443 credential from the hub to spoke clusters similar to the flow being done with brew credentials.