### PR TITLE
Modify ansible collection install flow (#534)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ARG ROSA_CLI=https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/rosa/l
 
 # The user ID set to match the one used in Jenkins and avoid permissions issues during job execution
 RUN mkdir -p /"$SUBM" \
-    && adduser -u 1006010000 "$SUBM" \
+    && adduser "$SUBM" \
     && chown -R "$SUBM" /"$SUBM"
 
 RUN dnf install --nodocs -y \
@@ -45,10 +45,10 @@ RUN wget -qO- "$OCP_CLI" | tar zxv -C /usr/local/bin/ oc kubectl \
 
 COPY requirements.txt requirements.yml ./
 
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt \
+    && mkdir -p /usr/share/ansible/collections \
+    && ansible-galaxy collection install --no-cache -r requirements.yml -p /usr/share/ansible/collections
 
 USER "$SUBM"
-
-RUN ansible-galaxy collection install --no-cache -r requirements.yml
 
 WORKDIR /"$SUBM"

--- a/jenkinsfiles/SubmarinerAgentPod.yaml
+++ b/jenkinsfiles/SubmarinerAgentPod.yaml
@@ -20,7 +20,7 @@ spec:
         cpu: 50m
         memory: 256Mi
   - name: submariner
-    image: 'quay.io/maxbab/subm-test@sha256:42893b4c5fd4f60fc32da810b88be9e69d14b618ecec4d19c4556e95cd9a4060'
+    image: 'quay.io/maxbab/subm-test@sha256:2d6c0a39865f5ffa55fafaea337777473325811d02a1641fbd93bb9a01e5deba'
     # imagePullSecrets: 'agent-image-secret'
     ttyEnabled: true
     alwaysPullImage: true
@@ -28,7 +28,9 @@ spec:
     workingDir: '/home/jenkins'
     env:
       - name: HOME
-        value: '/home/submariner'
+        value: '/home/jenkins'
+      - name: ANSIBLE_COLLECTIONS_PATHS
+        value: '/usr/share/ansible/collections'
     resources:
       limits:
         cpu: 2000m

--- a/playbooks/acm_import_cluster.yml
+++ b/playbooks/acm_import_cluster.yml
@@ -1,0 +1,7 @@
+- hosts: localhost
+  connection: local
+  gather_facts: false
+  collections:
+    - stolostron.rhacm
+  roles:
+    - acm_import_cluster

--- a/playbooks/managed_openshift.yml
+++ b/playbooks/managed_openshift.yml
@@ -1,0 +1,7 @@
+- hosts: localhost
+  connection: local
+  gather_facts: false
+  collections:
+    - stolostron.rhacm
+  roles:
+    - managed_openshift


### PR DESCRIPTION
- The image created from a Dockerfile, could be used both by jenkins CI or by any individual who would like to use automation and containerization flow, which means that users with different UID will be used. Modify ansible collection flow to be installed in a path that could be reachable by anyone without permission issues - '/usr/share/ansible/collections'.

- Add "ANSIBLE_COLLECTIONS_PATHS" environment variable to "SubmarinerAgentPod.yaml" file for jenkins and local containerized flow. That variable will point any user that will use an image to installed collection.

- Add "managed_openshift" and "acm_import_cluster" new playbooks.