### PR TITLE
Add stages to jenkins jobs

### DIFF
--- a/jenkinsfiles/aws-gcp-azure.Jenkinsfile
+++ b/jenkinsfiles/aws-gcp-azure.Jenkinsfile
@@ -5,7 +5,7 @@ podTemplate(yaml: readTrusted('jenkinsfiles/SubmarinerAgentPod.yaml')) {
         properties([
             parameters([
                 extendedChoice(name: 'JOB_STAGES', description: 'Select the stages of the job to be executed',
-                    value: 'Deploy OCP cluster,Deploy ACM Hub,Deploy Clusters by ACM,Submariner Validate prerequisites,Submariner Deploy,Submariner Test - E2E,Submariner Test - Cypress UI,Report to Polarion',
+                    value: 'Deploy OCP cluster,Deploy ACM Hub,Deploy Clusters by ACM,Deploy Managed OCP,Import OCP into ACM Hub,Submariner Validate prerequisites,Submariner Deploy,Submariner Test - E2E,Submariner Test - Cypress UI,Report to Polarion',
                     defaultValue: 'Deploy OCP cluster,Deploy ACM Hub,Deploy Clusters by ACM,Submariner Validate prerequisites,Submariner Deploy,Submariner Test - E2E,Submariner Test - Cypress UI,Report to Polarion',
                     multiSelectDelimiter: ',', type: 'PT_CHECKBOX', visibleItemCount: 10),
                 credentials(name: 'SUBMARINER_CONFIG', defaultValue: 'acm-2.9-subm-0.16-aws-gcp-azure', description: 'Submariner config for environment deploy',

--- a/jenkinsfiles/env-destroy.Jenkinsfile
+++ b/jenkinsfiles/env-destroy.Jenkinsfile
@@ -40,7 +40,7 @@ pipeline {
         stage('Destroy environment') {
             steps {
                 sh """
-                ansible-playbook -v playbooks/env_destroy.yml -e @"${SUBMARINER_CONF}"
+                ansible-playbook -v playbooks/ci/env_destroy.yml -e @"${SUBMARINER_CONF}"
                 """
             }
         }

--- a/jenkinsfiles/gcp-vsphere-rosa.Jenkinsfile
+++ b/jenkinsfiles/gcp-vsphere-rosa.Jenkinsfile
@@ -5,8 +5,8 @@ podTemplate(yaml: readTrusted('jenkinsfiles/SubmarinerAgentPod.yaml')) {
         properties([
             parameters([
                 extendedChoice(name: 'JOB_STAGES', description: 'Select the stages of the job to be executed',
-                    value: 'Deploy OCP cluster,Deploy ACM Hub,Deploy Clusters by ACM,Submariner Validate prerequisites,Submariner Deploy,Submariner Test - E2E,Submariner Test - Cypress UI,Report to Polarion',
-                    defaultValue: 'Deploy OCP cluster,Deploy ACM Hub,Deploy Clusters by ACM,Submariner Validate prerequisites,Submariner Deploy,Submariner Test - E2E,Submariner Test - Cypress UI,Report to Polarion',
+                    value: 'Deploy OCP cluster,Deploy ACM Hub,Deploy Clusters by ACM,Deploy Managed OCP,Import OCP into ACM Hub,Submariner Validate prerequisites,Submariner Deploy,Submariner Test - E2E,Submariner Test - Cypress UI,Report to Polarion',
+                    defaultValue: 'Deploy OCP cluster,Deploy ACM Hub,Deploy Clusters by ACM,Deploy Managed OCP,Import OCP into ACM Hub,Submariner Validate prerequisites,Submariner Deploy,Submariner Test - E2E,Submariner Test - Cypress UI,Report to Polarion',
                     multiSelectDelimiter: ',', type: 'PT_CHECKBOX', visibleItemCount: 10),
                 credentials(name: 'SUBMARINER_CONFIG', defaultValue: 'acm-2.9-subm-0.16-gcp-vsphere-rosa', description: 'Submariner config for environment deploy',
                     required: true, credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.FileCredentialsImpl')

--- a/playbooks/ci/acm.yml
+++ b/playbooks/ci/acm.yml
@@ -1,0 +1,9 @@
+---
+- name: Advanced Cluster Mnagement Hub
+  hosts: localhost
+  gather_facts: false
+  collections:
+    - stolostron.rhacm
+  roles:
+    - role: acm
+      when: run_acm

--- a/playbooks/ci/acm_hive_cluster.yml
+++ b/playbooks/ci/acm_hive_cluster.yml
@@ -1,0 +1,9 @@
+---
+- name: ACM Hive Clusters
+  hosts: localhost
+  gather_facts: false
+  collections:
+    - stolostron.rhacm
+  roles:
+    - role: acm_hive_cluster
+      when: run_acm_hive_cluster

--- a/playbooks/ci/acm_import_cluster.yml
+++ b/playbooks/ci/acm_import_cluster.yml
@@ -1,0 +1,8 @@
+- hosts: localhost
+  connection: local
+  gather_facts: false
+  collections:
+    - stolostron.rhacm
+  roles:
+    - role: acm_import_cluster
+      when: run_acm_import_cluster

--- a/playbooks/ci/managed_openshift.yml
+++ b/playbooks/ci/managed_openshift.yml
@@ -1,0 +1,8 @@
+- hosts: localhost
+  connection: local
+  gather_facts: false
+  collections:
+    - stolostron.rhacm
+  roles:
+    - role: managed_openshift
+      when: run_managed_openshift

--- a/playbooks/ci/ocp.yml
+++ b/playbooks/ci/ocp.yml
@@ -1,0 +1,9 @@
+---
+- name: OpenShift cluster
+  hosts: localhost
+  gather_facts: false
+  collections:
+    - stolostron.rhacm
+  roles:
+    - role: ocp
+      when: run_ocp


### PR DESCRIPTION
- Add the following stages to jenkins jobs:
  - Deploy Managed OCP
  - Import OCP into ACM Hub
- Create a dedicated CI playbooks to be able to control playbooks
  execution with a condition from the configuration files.