### PR TITLE
Reference ansible roles by FQDN

### DIFF
--- a/playbooks/acm.yml
+++ b/playbooks/acm.yml
@@ -2,7 +2,5 @@
 - name: Advanced Cluster Mnagement Hub
   hosts: localhost
   gather_facts: false
-  collections:
-    - stolostron.rhacm
   roles:
-    - acm
+    - stolostron.rhacm.acm

--- a/playbooks/acm_hive_cluster.yml
+++ b/playbooks/acm_hive_cluster.yml
@@ -2,7 +2,5 @@
 - name: ACM Hive Clusters
   hosts: localhost
   gather_facts: false
-  collections:
-    - stolostron.rhacm
   roles:
-    - acm_hive_cluster
+    - stolostron.rhacm.acm_hive_cluster

--- a/playbooks/acm_import_cluster.yml
+++ b/playbooks/acm_import_cluster.yml
@@ -1,7 +1,5 @@
 - hosts: localhost
   connection: local
   gather_facts: false
-  collections:
-    - stolostron.rhacm
   roles:
-    - acm_import_cluster
+    - stolostron.rhacm.acm_import_cluster

--- a/playbooks/ci/acm.yml
+++ b/playbooks/ci/acm.yml
@@ -2,8 +2,6 @@
 - name: Advanced Cluster Mnagement Hub
   hosts: localhost
   gather_facts: false
-  collections:
-    - stolostron.rhacm
   roles:
-    - role: acm
+    - role: stolostron.rhacm.acm
       when: run_acm

--- a/playbooks/ci/acm_hive_cluster.yml
+++ b/playbooks/ci/acm_hive_cluster.yml
@@ -2,8 +2,6 @@
 - name: ACM Hive Clusters
   hosts: localhost
   gather_facts: false
-  collections:
-    - stolostron.rhacm
   roles:
-    - role: acm_hive_cluster
+    - role: stolostron.rhacm.acm_hive_cluster
       when: run_acm_hive_cluster

--- a/playbooks/ci/acm_import_cluster.yml
+++ b/playbooks/ci/acm_import_cluster.yml
@@ -1,8 +1,6 @@
 - hosts: localhost
   connection: local
   gather_facts: false
-  collections:
-    - stolostron.rhacm
   roles:
-    - role: acm_import_cluster
+    - role: stolostron.rhacm.acm_import_cluster
       when: run_acm_import_cluster

--- a/playbooks/ci/env_deploy.yml
+++ b/playbooks/ci/env_deploy.yml
@@ -3,16 +3,14 @@
   gather_facts: false
   vars:
     state: present
-  collections:
-    - stolostron.rhacm
   roles:
-    - role: ocp
+    - role: stolostron.rhacm.ocp
       when: run_ocp
-    - role: acm
+    - role: stolostron.rhacm.acm
       when: run_acm
-    - role: acm_hive_cluster
+    - role: stolostron.rhacm.acm_hive_cluster
       when: run_acm_hive_cluster
-    - role: managed_openshift
+    - role: stolostron.rhacm.managed_openshift
       when: run_managed_openshift
-    - role: acm_import_cluster
+    - role: stolostron.rhacm.acm_import_cluster
       when: run_acm_import_cluster

--- a/playbooks/ci/env_destroy.yml
+++ b/playbooks/ci/env_destroy.yml
@@ -3,14 +3,12 @@
   gather_facts: false
   vars:
     state: absent
-  collections:
-    - stolostron.rhacm
   roles:
-    - role: acm_import_cluster
+    - role: stolostron.rhacm.acm_import_cluster
       when: run_acm_import_cluster
-    - role: managed_openshift
+    - role: stolostron.rhacm.managed_openshift
       when: run_managed_openshift
-    - role: acm_hive_cluster
+    - role: stolostron.rhacm.acm_hive_cluster
       when: run_acm_hive_cluster
-    - role: ocp
+    - role: stolostron.rhacm.ocp
       when: run_ocp

--- a/playbooks/ci/managed_openshift.yml
+++ b/playbooks/ci/managed_openshift.yml
@@ -1,8 +1,6 @@
 - hosts: localhost
   connection: local
   gather_facts: false
-  collections:
-    - stolostron.rhacm
   roles:
-    - role: managed_openshift
+    - role: stolostron.rhacm.managed_openshift
       when: run_managed_openshift

--- a/playbooks/ci/ocp.yml
+++ b/playbooks/ci/ocp.yml
@@ -2,8 +2,6 @@
 - name: OpenShift cluster
   hosts: localhost
   gather_facts: false
-  collections:
-    - stolostron.rhacm
   roles:
-    - role: ocp
+    - role: stolostron.rhacm.ocp
       when: run_ocp

--- a/playbooks/env_deploy.yml
+++ b/playbooks/env_deploy.yml
@@ -3,9 +3,7 @@
   gather_facts: false
   vars:
     state: present
-  collections:
-    - stolostron.rhacm
   roles:
-    - ocp
-    - acm
-    - acm_hive_cluster
+    - stolostron.rhacm.ocp
+    - stolostron.rhacm.acm
+    - stolostron.rhacm.acm_hive_cluster

--- a/playbooks/env_destroy.yml
+++ b/playbooks/env_destroy.yml
@@ -3,8 +3,6 @@
   gather_facts: false
   vars:
     state: absent
-  collections:
-    - stolostron.rhacm
   roles:
-    - acm_hive_cluster
-    - ocp
+    - stolostron.rhacm.acm_hive_cluster
+    - stolostron.rhacm.ocp

--- a/playbooks/managed_openshift.yml
+++ b/playbooks/managed_openshift.yml
@@ -1,7 +1,5 @@
 - hosts: localhost
   connection: local
   gather_facts: false
-  collections:
-    - stolostron.rhacm
   roles:
-    - managed_openshift
+    - stolostron.rhacm.managed_openshift

--- a/playbooks/ocp.yml
+++ b/playbooks/ocp.yml
@@ -2,7 +2,5 @@
 - name: OpenShift cluster
   hosts: localhost
   gather_facts: false
-  collections:
-    - stolostron.rhacm
   roles:
-    - ocp
+    - stolostron.rhacm.ocp


### PR DESCRIPTION
According to ansible-lint the roles should be referenced by fqdn and not define a collection separatelly.