### PR TITLE
Update `subctl` binary name

### DIFF
--- a/lib/common/prerequisites.sh
+++ b/lib/common/prerequisites.sh
@@ -108,8 +108,8 @@ function get_subctl_for_testing() {
     tar xfJ subctl.tar.xz --strip-components 1
 
     mkdir -p "$HOME"/.local/bin
-    install subctl*linux-amd64 "$HOME"/.local/bin/subctl
-    rm -f subctl.tar.xz subctl*linux-amd64
+    install subctl "$HOME"/.local/bin/subctl
+    rm -f subctl.tar.xz subctl
 
     # Add local BIN dir to PATH
     [[ ":$PATH:" == *":$HOME/.local/bin:"* ]] || export PATH="$HOME/.local/bin:$PATH"


### PR DESCRIPTION
Starting Submariner v0.16, `subctl` binary has been renamed to just `subctl` inside the tar. This PR updates the name from `subctl*linux-amd64` to `subctl`.