### PR TITLE
Modify subctl fetch from official registry

### DIFF
--- a/jenkinsfiles/acm-qe.Jenkinsfile
+++ b/jenkinsfiles/acm-qe.Jenkinsfile
@@ -37,6 +37,8 @@ pipeline {
         // The secret contains polarion authentication
         // and other details for report publish
         POLARION_SECRET = credentials('submariner-polarion-secret')
+        // Credentials for the registry.redhat.io
+        RH_REG = credentials('submariner-rh-registry')
     }
     stages {
         // This stage will validate the environment for the job.

--- a/jenkinsfiles/base.Jenkinsfile
+++ b/jenkinsfiles/base.Jenkinsfile
@@ -31,6 +31,8 @@ pipeline {
         // and other details for report publish
         POLARION_SECRET = credentials('submariner-polarion-secret')
         SUBMARINER_CONF = credentials('SUBMARINER_CONFIG')
+        // Credentials for the registry.redhat.io
+        RH_REG = credentials('submariner-rh-registry')
     }
     stages {
         // Environment vars defined within "environment" block

--- a/lib/common/prerequisites.sh
+++ b/lib/common/prerequisites.sh
@@ -84,23 +84,15 @@ function get_subctl_for_testing() {
     if [[ "$DOWNSTREAM" == "true" ]]; then
         INFO "Download downstream subctl binary for testing"
         subctl_download_url="$VPN_REGISTRY/$REGISTRY_IMAGE_IMPORT_PATH/$image_prefix-subctl-rhel8:$subctl_version"
-        INFO "Download subctl from - $subctl_download_url"
-        oc image extract --insecure=true "$subctl_download_url" --path=/dist/subctl-*-linux-amd64.tar.xz:./ --confirm
-        mv subctl-*-linux-amd64.tar.xz subctl.tar.xz
-
-        # Untill the https://github.com/submariner-io/subctl/pull/526 patch will be available downstream,
-        # use upstream subctl binary
-
-        # INFO "Download subctl binary for testing"
-        # subctl_version="${subctl_version:1:4}"
-        # subctl_download_url="$SUBCTL_UPSTREAM_URL/releases/download/subctl-release-$subctl_version/subctl-release-$subctl_version-linux-amd64.tar.xz"
-        # INFO "Download subctl from - $subctl_download_url"
-        # wget -qO- "$subctl_download_url" -O subctl.tar.xz
     else
-        INFO "Download upstream subctl binary for testing"
-        subctl_download_url="$SUBCTL_URL_DOWNLOAD/releases/download/${subctl_version}/subctl-${subctl_version}-linux-amd64.tar.xz"
-        wget -qO- "$subctl_download_url" -O subctl.tar.xz
+        INFO "Download subctl binary for testing from official RH registry - registry.redhat.io"
+        oc registry login --registry "$OFFICIAL_REGISTRY" --auth-basic="${RH_REG_USR}:${RH_REG_PSW}"
+        subctl_download_url="$OFFICIAL_REGISTRY/$REGISTRY_IMAGE_PREFIX/subctl-rhel8:$subctl_version"
     fi
+
+    INFO "Download subctl from - $subctl_download_url"
+    oc image extract --insecure=true "$subctl_download_url" --path=/dist/subctl-*-linux-amd64.tar.xz:./ --confirm
+    mv subctl-*-linux-amd64.tar.xz subctl.tar.xz
 
     INFO "Submariner addon version - $subctl_version"
     INFO "Download subctl from - $subctl_download_url"

--- a/run.sh
+++ b/run.sh
@@ -43,6 +43,15 @@ function verify_required_env_vars() {
             'OC_CLUSTER_USER', 'OC_CLUSTER_PASS', 'OC_CLUSTER_API'"
         fi
     fi
+    if [[ "$DOWNSTREAM" == "false" ]]; then
+        if [[ -z "$RH_REG_USR" || -z "$RH_REG_PSW" ]]; then
+            if [[ "$RUN_COMMAND" == "validate-prereq" ]]; then
+                VALIDATION_STATE+="Not ready! Missing OFFICIAL_REG_USER or OFFICIAL_REG_PASS environment vars."
+            else
+                ERROR "Execution of the script require the following env variables provided: OFFICIAL_REG_USER and OFFICIAL_REG_PASS"
+            fi
+        fi
+    fi
 }
 
 # The function is used by ci to validate the environment for prerequisites.


### PR DESCRIPTION
When "subctl" binary was not built downstream, during the testing pipeline, it was fetched from the upstream (github). Once the "subctl" binary started to built downstream and shipped to the customers, the downstream testing pipeline, used it to test and validate the binary alongside with all other submarienr components. But "post-publishing" flow, which should test the submariner once it gets GA, still fetched the "subctl" from the upstream (github). The "post-publishing" pipeline, should test all submariner components once released to ensure the customer gets all the components in a working state.

Modify the "post-publishing" flow in order to fetch the "subctl" binary from the official RH registry - registry.redhat.io. Once executed with "--downstream false" flag, the execution will expect to get "OFFICIAL_REG_USER" and "OFFICIAL_REG_PASS" environment variables to be able to fetch the required binary.