### PR TITLE
Add ROSA machineset creation flow

### DIFF
--- a/lib/common/prerequisites.sh
+++ b/lib/common/prerequisites.sh
@@ -53,6 +53,24 @@ function verify_jq() {
     INFO "The jq command is found"
 }
 
+# ROSA (aws ocp managed cluster)
+function verify_rosa_cli() {
+    if ! command -v rosa &> /dev/null; then
+        WARNING "Missing rosa command. Installing..."
+        mkdir -p "$HOME"/.local/bin
+        wget -qO- "https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/rosa/latest/rosa-linux.tar.gz" \
+            -O rosa.tar.gz
+        tar zxvf rosa.tar.gz
+        rm -f rosa.tar.gz
+        mv rosa "$HOME"/.local/bin
+
+        # Add local BIN dir to PATH
+        [[ ":$PATH:" = *":$HOME/.local/bin:"* ]] || export PATH="$HOME/.local/bin:$PATH"
+        INFO "The oc and kubectl installed"
+    fi
+    INFO "The rosa command is found"
+}
+
 function verify_prerequisites_tools() {
     INFO "Verify prerequisites tools"
     verify_ocp_clients

--- a/lib/submariner_deploy/submariner_deploy.sh
+++ b/lib/submariner_deploy/submariner_deploy.sh
@@ -53,7 +53,31 @@ function prepare_clusters_for_submariner() {
         if [[ "$reset_gw_count" == "true" ]]; then
             SUBMARINER_GATEWAY_COUNT=1
         fi
+
+        if [[ "$product" == "ROSA" ]]; then
+            deploy_gw_node_for_rosa "$cluster"
+        fi
     done
+}
+
+# Deploying GW node for ROSA cluster should
+# be done by using "rosa" binary.
+function deploy_gw_node_for_rosa() {
+    INFO "Deploy Gateway node for ROSA cluster"
+    local cluster="$1"
+    local machinepool_name="sm-gw-mp"
+    local machinepool_state
+
+    rosa login --token "$ROSA_TOKEN"
+    machinepool_state=$(rosa list machinepool --cluster "$cluster" -o json \
+        | jq -r '.[] | select(.id | contains("'"$machinepool_name"'")).id')
+
+    # Until https://issues.redhat.com/browse/ACM-2494 is fixed,
+    # create 3 machinepool replicas.
+    if [[ "$machinepool_state" == "" ]]; then
+        rosa create machinepool --cluster="$cluster" \
+            --name="$machinepool_name" --replicas=3 --labels='submariner.io/gateway=true'
+    fi
 }
 
 function deploy_submariner_broker() {

--- a/run.sh
+++ b/run.sh
@@ -52,6 +52,16 @@ function verify_required_env_vars() {
             fi
         fi
     fi
+    if [[ "$PLATFORM" =~ "rosa" ]]; then
+        if [[ -z "${ROSA_TOKEN}" ]]; then
+            if [[ "$RUN_COMMAND" == "validate-prereq" ]]; then
+                VALIDATION_STATE+="Not ready! Missing environment vars. Unable to login to the hub."
+            else
+                ERROR "Execution of the script require the following env variable provided:
+                'ROSA_TOKEN'"
+            fi
+        fi
+    fi
 }
 
 # The function is used by ci to validate the environment for prerequisites.
@@ -97,6 +107,13 @@ function deploy_submariner() {
     mkdir -p "$TESTS_LOGS"
 
     select_submariner_version_and_channel_to_deploy
+
+    if [[ "$PLATFORM" =~ "rosa" ]]; then
+        # ROSA (aws ocp managed cluster) requires to create
+        # submariner gateway node by using "rosa" binary.
+        INFO "Fetch 'rosa' binary"
+        verify_rosa_cli
+    fi
 
     if [[ "$DOWNSTREAM" == 'true' ]]; then
         create_brew_secret


### PR DESCRIPTION
Adding back previously removed machineset creation flow for ROSA cluster.
In ACM 2.7 version, automatic submarienr gateway node creation is still not supported as in the newer versions.