### PR TITLE
Add manual submariner GW node labeling

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,15 @@ export OC_CLUSTER_PASS=<password of the cluster user>
                              (Optional)
                              By default - false
 
+    --subm-catalog-update  - Update CatalogSource to the latest version of Submariner.
+                             Used in upgrade flow scenario.
+                             (Optional)
+
+    --subm-label-gw-node   - Manually label Submariner Gateway node for the specified clusters.
+                             Separate multiple clusters by comma.
+                             (Optional)
+                             By default, no used.
+
     Reporting arguments:
     --------------------
     --polarion-vars-file   - A path to the file that contains Polarion details.

--- a/lib/common/helper_functions.sh
+++ b/lib/common/helper_functions.sh
@@ -147,6 +147,15 @@ function usage() {
                              (Optional)
                              By default - false
 
+    --subm-catalog-update  - Update CatalogSource to the latest version of Submariner.
+                             Used in upgrade flow scenario.
+                             (Optional)
+
+    --subm-label-gw-node   - Manually label Submariner Gateway node for the specified clusters.
+                             Separate multiple clusters by comma.
+                             (Optional)
+                             By default, no used.
+
     Reporting arguments:
     --------------------
     --polarion-vars-file   - A path to the file that contains Polarion details.

--- a/run.sh
+++ b/run.sh
@@ -43,7 +43,7 @@ function verify_required_env_vars() {
             'OC_CLUSTER_USER', 'OC_CLUSTER_PASS', 'OC_CLUSTER_API'"
         fi
     fi
-    if [[ "$DOWNSTREAM" == "false" ]]; then
+    if [[ "$DOWNSTREAM" == "false" && "$RUN_COMMAND" == "test" ]]; then
         if [[ -z "$RH_REG_USR" || -z "$RH_REG_PSW" ]]; then
             if [[ "$RUN_COMMAND" == "validate-prereq" ]]; then
                 VALIDATION_STATE+="Not ready! Missing OFFICIAL_REG_USER or OFFICIAL_REG_PASS environment vars."
@@ -244,6 +244,12 @@ function parse_arguments() {
             --subm-gateway-random)
                 if [[ -n "$2" ]]; then
                     export SUBMARINER_GATEWAY_RANDOM="$2"
+                    shift 2
+                fi
+                ;;
+            --subm-label-gw-node)
+                if [[ -n "$2" ]]; then
+                    export SUBMARINER_MANUAL_LABEL_GW_NODE="$2"
                     shift 2
                 fi
                 ;;

--- a/variables
+++ b/variables
@@ -63,6 +63,8 @@ export DOWNSTREAM_CATALOG_SOURCE="submariner-catalog"
 # on first cluster and 1 gateway on other clusters
 # Used by the testing pipeline
 export SUBMARINER_GATEWAY_RANDOM="false"
+# Manually label Submariner Gateway node for the specified clusters.
+export SUBMARINER_MANUAL_LABEL_GW_NODE=""
 # Official RedHat registry
 export OFFICIAL_REGISTRY="registry.redhat.io"
 export STAGING_REGISTRY="registry.stage.redhat.io"


### PR DESCRIPTION
It's possible in submariner deployment to manually pre-label the one of the cluster nodes with GW label and during the deployment process of Submariner, that node will be used as the Submarienr Gateway node.

Add this flow to be able to test such scenario.