### PR TITLE
Skip cloud creds check for OSP platform

### DIFF
--- a/lib/submariner_deploy/submariner_deploy.sh
+++ b/lib/submariner_deploy/submariner_deploy.sh
@@ -19,7 +19,7 @@ function prepare_clusters_for_submariner() {
         creds=$(get_cluster_credential_name "$cluster")
         platform=$(get_cluster_platform "$cluster")
         product=$(get_cluster_product "$cluster")
-        if [[ "$platform" =~ ("IBMPowerPlatform") ]]; then
+        if [[ "$platform" =~ ("IBMPowerPlatform"|"OpenStack") ]]; then
             creds="null"
         fi
         # The ARO / ROSA cluster does not need cloud credentials


### PR DESCRIPTION
In submariner qe test scenario, osp platform will be manual labeled for the Submariner GW nodes.