### PR TITLE
Jenkins - move specific subm params to jobs level

### DIFF
--- a/jenkinsfiles/aws-gcp-azure.Jenkinsfile
+++ b/jenkinsfiles/aws-gcp-azure.Jenkinsfile
@@ -4,6 +4,8 @@ podTemplate(yaml: readTrusted('jenkinsfiles/SubmarinerAgentPod.yaml')) {
 
         properties([
             parameters([
+                booleanParam(name: 'GLOBALNET', defaultValue: false, description: 'Deploy Globalnet on Submariner'),
+                booleanParam(name: 'DOWNSTREAM', defaultValue: true, description: 'Deploy downstream version of Submariner'),
                 extendedChoice(name: 'JOB_STAGES', description: 'Select the stages of the job to be executed',
                     value: 'Deploy OCP cluster,Deploy ACM Hub,Deploy Clusters by ACM,Deploy Managed OCP,Import OCP into ACM Hub,Submariner Validate prerequisites,Submariner Deploy,Submariner Test - E2E,Submariner Test - Cypress UI,Report to Polarion',
                     defaultValue: 'Deploy OCP cluster,Deploy ACM Hub,Deploy Clusters by ACM,Submariner Validate prerequisites,Submariner Deploy,Submariner Test - E2E,Submariner Test - Cypress UI,Report to Polarion',

--- a/jenkinsfiles/base.Jenkinsfile
+++ b/jenkinsfiles/base.Jenkinsfile
@@ -19,8 +19,6 @@ pipeline {
         string(name: 'OC_CLUSTER_PASS', defaultValue: '', description: 'ACM Hub password')
         extendedChoice(name: 'PLATFORM', description: 'The managed clusters platform that should be tested',
             value: 'aws,gcp,azure,vsphere,aro,rosa', defaultValue: 'aws,gcp,azure,vsphere,aro,rosa', multiSelectDelimiter: ',', type: 'PT_CHECKBOX', visibleItemCount: 6)
-        booleanParam(name: 'GLOBALNET', defaultValue: true, description: 'Deploy Globalnet on Submariner')
-        booleanParam(name: 'DOWNSTREAM', defaultValue: true, description: 'Deploy downstream version of Submariner')
         booleanParam(name: 'SUBMARINER_GATEWAY_RANDOM', defaultValue: true, description: 'Deploy two submariner gateways on one of the clusters')
     }
     environment {

--- a/jenkinsfiles/gcp-vsphere-rosa.Jenkinsfile
+++ b/jenkinsfiles/gcp-vsphere-rosa.Jenkinsfile
@@ -4,6 +4,8 @@ podTemplate(yaml: readTrusted('jenkinsfiles/SubmarinerAgentPod.yaml')) {
 
         properties([
             parameters([
+                booleanParam(name: 'GLOBALNET', defaultValue: true, description: 'Deploy Globalnet on Submariner'),
+                booleanParam(name: 'DOWNSTREAM', defaultValue: true, description: 'Deploy downstream version of Submariner'),
                 extendedChoice(name: 'JOB_STAGES', description: 'Select the stages of the job to be executed',
                     value: 'Deploy OCP cluster,Deploy ACM Hub,Deploy Clusters by ACM,Deploy Managed OCP,Import OCP into ACM Hub,Submariner Validate prerequisites,Submariner Deploy,Submariner Test - E2E,Submariner Test - Cypress UI,Report to Polarion',
                     defaultValue: 'Deploy OCP cluster,Deploy ACM Hub,Deploy Clusters by ACM,Deploy Managed OCP,Import OCP into ACM Hub,Submariner Validate prerequisites,Submariner Deploy,Submariner Test - E2E,Submariner Test - Cypress UI,Report to Polarion',


### PR DESCRIPTION
The following submariner parameters are moved from the base jenkinsfile level to the individual jobs levels.
- Globalnet
- Downstream