### PR TITLE
Improve upgrade flow

### DIFF
--- a/lib/common/helper_functions.sh
+++ b/lib/common/helper_functions.sh
@@ -349,6 +349,27 @@ function increase_minor_version() {
     echo "$version"
 }
 
+function fetch_multiclusterhub_version() {
+    local mch_version
+
+    mch_version=$(oc get multiclusterhub -A -o jsonpath='{.items[0].status.currentVersion}')
+    echo "$mch_version"
+}
+
+function fetch_installed_submariner_version() {
+    local primary_cl="$1"  # optional
+    local subm_ver
+
+    if [[ -z "$primary_cl" ]]; then
+        primary_cl=$(echo "$MANAGED_CLUSTERS" | head -n 1)
+    fi
+
+    subm_ver=$(KUBECONFIG="$KCONF/$primary_cl-kubeconfig.yaml" \
+        oc -n "$SUBMARINER_NS" get submariner submariner -o jsonpath='{.status.version}' \
+        | grep -Po '(?<=v)[^)]*')
+    echo "$subm_ver"
+}
+
 function catch_error() {
     if [[ "$1" != "0" ]]; then
         if [[ "$SKIP_GATHER_LOGS" == "false" ]]; then

--- a/lib/common/prerequisites.sh
+++ b/lib/common/prerequisites.sh
@@ -60,34 +60,21 @@ function verify_prerequisites_tools() {
     verify_jq
 }
 
-
-### Prerequisites tools install for test
-function fetch_submariner_addon_version() {
-    local sub_cluster_ns
-    local sub_version
-
-    sub_cluster_ns=$(echo "$MANAGED_CLUSTERS" | head -n 1)
-    sub_version=$(oc get managedclusteraddon/submariner -n "$sub_cluster_ns" \
-                    -o jsonpath='{.status.conditions[?(@.type == "SubmarinerAgentDegraded")].message}' \
-                    | grep -Po '(?<=submariner.)[^)]*')
-    echo "$sub_version"
-}
-
 function get_subctl_for_testing() {
     INFO "Installing subctl client"
 
     local image_prefix="$REGISTRY_IMAGE_PREFIX"
     local subctl_version
     local subctl_download_url
-    subctl_version=$(fetch_submariner_addon_version | cut -d '-' -f1)
+    subctl_version=$(fetch_installed_submariner_version)
 
     if [[ "$DOWNSTREAM" == "true" ]]; then
         INFO "Download downstream subctl binary for testing"
-        subctl_download_url="$VPN_REGISTRY/$REGISTRY_IMAGE_IMPORT_PATH/$image_prefix-subctl-rhel8:$subctl_version"
+        subctl_download_url="$VPN_REGISTRY/$REGISTRY_IMAGE_IMPORT_PATH/$image_prefix-subctl-rhel8:v$subctl_version"
     else
         INFO "Download subctl binary for testing from official RH registry - registry.redhat.io"
         oc registry login --registry "$OFFICIAL_REGISTRY" --auth-basic="${RH_REG_USR}:${RH_REG_PSW}"
-        subctl_download_url="$OFFICIAL_REGISTRY/$REGISTRY_IMAGE_PREFIX/subctl-rhel8:$subctl_version"
+        subctl_download_url="$OFFICIAL_REGISTRY/$REGISTRY_IMAGE_PREFIX/subctl-rhel8:v$subctl_version"
     fi
 
     INFO "Download subctl from - $subctl_download_url"
@@ -119,7 +106,7 @@ function verify_subctl_command() {
     local submariner_version
     local subctl_client
 
-    submariner_version=$(fetch_submariner_addon_version)
+    submariner_version=$(fetch_installed_submariner_version)
     subctl_client=$(get_subctl_version)
 
     if ! command -v subctl &> /dev/null; then

--- a/lib/submariner_prepare/acm_prepare_for_submariner.sh
+++ b/lib/submariner_prepare/acm_prepare_for_submariner.sh
@@ -38,13 +38,6 @@ function assign_clusters_to_clusterset() {
     INFO "Clusters have been assigned to the clusterset $CLUSTERSET. Assigned: $MANAGED_CLUSTERS"
 }
 
-function fetch_multiclusterhub_version() {
-    local mch_version
-
-    mch_version=$(oc get multiclusterhub -A -o jsonpath='{.items[0].status.currentVersion}')
-    echo "$mch_version"
-}
-
 # The submariner version selection will be done
 # when brew image source will be selected.
 # Otherwise, it will install from official source:
@@ -60,11 +53,10 @@ function select_submariner_version_and_channel_to_deploy() {
     declare -n acm_ref
     for acm_ref in "${COMPONENT_VERSIONS[@]}"; do
         if [[ "$mch_ver" == "${acm_ref[acm_version]}"* ]]; then
-            ACM_VERSION="$mch_ver"
             SUBMARINER_VERSION_INSTALL="${acm_ref[submariner_version]}"
             SUBMARINER_CHANNEL_RELEASE="${acm_ref[channel]}"
             INFO "Submariner version - $SUBMARINER_VERSION_INSTALL will be installed
-            into the '$SUBMARINER_CHANNEL_RELEASE' channel with ACM $ACM_VERSION"
+            into the '$SUBMARINER_CHANNEL_RELEASE' channel"
         fi
     done
 

--- a/lib/submariner_test/submariner_test.sh
+++ b/lib/submariner_test/submariner_test.sh
@@ -58,10 +58,7 @@ function combine_tests_basename() {
     fi
 
     acm_ver=$(oc get multiclusterhub -A -o jsonpath='{.items[0].status.currentVersion}' | cut -d '-' -f1)
-    subm_ver=$(KUBECONFIG="$KCONF/$primary_cluster-kubeconfig.yaml" \
-        oc -n submariner-operator get subs submariner \
-        -o jsonpath='{.status.currentCSV}' \
-        | grep -Po '(?<=submariner.v)[^)]*' | cut -d '-' -f1)
+    subm_ver=$(fetch_installed_submariner_version "$primary_cluster")
 
     globalnet_state=$(KUBECONFIG="$KCONF/$primary_cluster-kubeconfig.yaml" \
         oc -n submariner-operator get pods -l=app=submariner-globalnet \

--- a/run.sh
+++ b/run.sh
@@ -128,7 +128,6 @@ function report() {
 }
 
 function upgrade() {
-    select_submariner_version_and_channel_to_deploy
     update_subm_catalog_source
     update_acm_catalog_source
     perform_acm_upgrade

--- a/variables
+++ b/variables
@@ -61,8 +61,6 @@ export COMPONENT_VERSIONS=("${!ACM@}")
 # Note - the use of brew will require a secret with brew credentials to present in cluster
 # If DOWNSTREAM flag is set to "true", it will fetch downstream images.
 export DOWNSTREAM="false"
-export ACM_VERSION=""
-export ACM_SNAPSHOT=""
 # The submariner version will be defined and used
 # if the source of the images will be set to quay (downstream).
 # The submariner version will be selected automatically.
@@ -95,6 +93,10 @@ export POLARION_VARS_FILE=""
 export POLARION_ADD_SKIPPED="false"
 
 export LATEST_IIB=""
+
+# Upgrade parameters
+export ACM_UPGRADE_VERSION=""
+export ACM_UPGRADE_SNAPSHOT=""
 
 # Test type that should be executed.
 # e2e (api testing), ui (cypress testing)


### PR DESCRIPTION
Modify the upgrade flow to the following steps:
- Fetch existing acm hub version.
- Fetch existing submariner version.
- Increase the version of both versions above.
- Update the catalog sources of of both acm and submariner.
- Trigger the acm upgrade flow and wait for it to complete.

The improvement comes from fetching the existing installed version and not by allocating the versions from the "variables" array. It will allow to execute the upgrade from the "newer" version branch and will prevent a non matching version error.