### PR TITLE
Add Submariner version verify for upgrade

### DIFF
--- a/variables
+++ b/variables
@@ -97,6 +97,7 @@ export LATEST_IIB=""
 # Upgrade parameters
 export ACM_UPGRADE_VERSION=""
 export ACM_UPGRADE_SNAPSHOT=""
+export SUBMARINER_UPGRADE_VERSION=""
 
 # Test type that should be executed.
 # e2e (api testing), ui (cypress testing)


### PR DESCRIPTION
During upgrade flow, as acm hub has been upgraded, we need to verify Submariner has been upgraded as well.
Add that step to an upgrade flow.