### PR TITLE
Add volume mapping to Jenkins pod

### DIFF
--- a/jenkinsfiles/SubmarinerAgentPod.yaml
+++ b/jenkinsfiles/SubmarinerAgentPod.yaml
@@ -38,3 +38,11 @@ spec:
       requests:
         cpu: 2000m
         memory: 3Gi
+    volumeMounts:
+      - name: skynet-data
+        mountPath: '/var/skynet-data'
+        readOnly: false
+  volumes:
+    - name: skynet-data
+      persistentVolumeClaim:
+        claimName: skynet-workspace


### PR DESCRIPTION
Add a volume mapping to a Jenkins pod to be able to pass config file between pods and jobs if required.