### PR TITLE
Fix downstream deployment failure

### DIFF
--- a/variables
+++ b/variables
@@ -130,6 +130,8 @@ export SUBMARINER_CHANNEL_RELEASE=""
 export SUBMARINER_IPSEC_NATT_PORT=4505
 export SUBMARINER_CABLE_DRIVER="libreswan"
 export SUBMARINER_GATEWAY_COUNT=1
+# The default catalog source is - redhat-operators
+export DOWNSTREAM_CATALOG_SOURCE="submariner-catalog"
 # When set to true, the deployment will set 2 gateways
 # on first cluster and 1 gateway on other clusters
 # Used by the testing pipeline


### PR DESCRIPTION
The "variables" file was missing the "DOWNSTREAM_CATALOG_SOURCE" variable statement, which lead to a downstream deployment failure.