### PR TITLE
Fix submariner version fetch

### DIFF
--- a/lib/common/helper_functions.sh
+++ b/lib/common/helper_functions.sh
@@ -365,7 +365,7 @@ function fetch_installed_submariner_version() {
     fi
 
     subm_ver=$(KUBECONFIG="$KCONF/$primary_cl-kubeconfig.yaml" \
-        oc -n "$SUBMARINER_NS" get submariner submariner -o jsonpath='{.status.version}' \
+        oc -n "$SUBMARINER_NS" get Gateway -o jsonpath='{.items[0].status.version}' \
         | grep -Po '(?<=v)[^)]*')
     echo "$subm_ver"
 }


### PR DESCRIPTION
During submariner testing an installed version should be fetched.
Fix a bug with fetching the installed version.