### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,8 @@ RUN dnf install --nodocs -y \
     && dnf install -y nodejs \
     && dnf install -y "$CHROME" \
     && dnf clean all \
-    && rm -rf /var/cache/yum
+    && rm -rf /var/cache/yum \
+    && update-alternatives --install /usr/bin/python python /usr/bin/python3 1
 
 RUN wget -qO- "$OCP_CLI" | tar zxv -C /usr/local/bin/ oc kubectl \
     && wget -qO- "$YQ" -O /usr/local/bin/yq && chmod +x /usr/local/bin/yq \


### PR DESCRIPTION
In fedora 39 image version, "python" command is not available as only python3 is installed in the image.
Some ansible modules are trying to use "python" instead of "python3".

So solve it, use the "update-alternatives" to create a "python" alias to "python3".