### PR TITLE
Modify Submariner version selection

### DIFF
--- a/variables
+++ b/variables
@@ -32,18 +32,12 @@ export VALIDATION_STATE=""
 # The value will define the version of Submariner and a channel
 
 # Declare associative arrays for acm/submariner versions
-declare -A ACM_2_10_0=(
-    [acm_version]='2.10.0'
-    [submariner_version]='0.17.0'
+declare -A ACM_2_10=(
+    [acm_version]='2.10'
+    [submariner_version]='0.17'
     [channel]='stable'
 )
-export ACM_2_10_0
-declare -A ACM_2_10_1=(
-    [acm_version]='2.10.1'
-    [submariner_version]='0.17.0'
-    [channel]='stable'
-)
-export ACM_2_10_1
+export ACM_2_10
 
 # Declare array of COMPONENTS_VERSIONS of associative arrays
 export COMPONENT_VERSIONS=("${!ACM@}")


### PR DESCRIPTION
Modify the definition of Submariner to ACM varsion alignment to deploy always the latest z-stream submariner version available aligned to installed ACM.