### PR TITLE
Modify Submariner version selection

### DIFF
--- a/variables
+++ b/variables
@@ -32,30 +32,12 @@ export VALIDATION_STATE=""
 # The value will define the version of Submariner and a channel
 
 # Declare associative arrays for acm/submariner versions
-declare -A ACM_2_9_0=(
-    [acm_version]='2.9.0'
-    [submariner_version]='0.16.2'
+declare -A ACM_2_9=(
+    [acm_version]='2.9'
+    [submariner_version]='0.16'
     [channel]='stable'
 )
-export ACM_2_9_0
-declare -A ACM_2_9_1=(
-    [acm_version]='2.9.1'
-    [submariner_version]='0.16.2'
-    [channel]='stable'
-)
-export ACM_2_9_1
-declare -A ACM_2_9_2=(
-    [acm_version]='2.9.2'
-    [submariner_version]='0.16.3'
-    [channel]='stable'
-)
-export ACM_2_9_2
-declare -A ACM_2_9_3=(
-    [acm_version]='2.9.3'
-    [submariner_version]='0.16.3'
-    [channel]='stable'
-)
-export ACM_2_9_3
+export ACM_2_9
 
 # Declare array of COMPONENTS_VERSIONS of associative arrays
 export COMPONENT_VERSIONS=("${!ACM@}")


### PR DESCRIPTION
Modify the definition of Submariner to ACM varsion alignment to deploy always the latest z-stream submariner version available aligned to installed ACM.