### PR TITLE
Modify Submariner version selection

### DIFF
--- a/variables
+++ b/variables
@@ -34,46 +34,10 @@ export VALIDATION_STATE=""
 # Declare associative arrays for acm/submariner versions
 declare -A ACM_2_8=(
     [acm_version]='2.8'
-    [submariner_version]='0.15.1'
+    [submariner_version]='0.15'
     [channel]='stable'
 )
 export ACM_2_8
-declare -A ACM_2_8_1=(
-    [acm_version]='2.8.1'
-    [submariner_version]='0.15.2'
-    [channel]='stable'
-)
-export ACM_2_8_1
-declare -A ACM_2_8_2=(
-    [acm_version]='2.8.2'
-    [submariner_version]='0.15.2'
-    [channel]='stable'
-)
-export ACM_2_8_2
-declare -A ACM_2_8_3=(
-    [acm_version]='2.8.3'
-    [submariner_version]='0.15.2'
-    [channel]='stable'
-)
-export ACM_2_8_3
-declare -A ACM_2_8_4=(
-    [acm_version]='2.8.4'
-    [submariner_version]='0.15.3'
-    [channel]='stable'
-)
-export ACM_2_8_4
-declare -A ACM_2_8_5=(
-    [acm_version]='2.8.5'
-    [submariner_version]='0.15.3'
-    [channel]='stable'
-)
-export ACM_2_8_5
-declare -A ACM_2_8_6=(
-    [acm_version]='2.8.6'
-    [submariner_version]='0.15.3'
-    [channel]='stable'
-)
-export ACM_2_8_6
 
 # Declare array of COMPONENTS_VERSIONS of associative arrays
 export COMPONENT_VERSIONS=("${!ACM@}")


### PR DESCRIPTION
Modify the definition of Submariner to ACM varsion alignment to deploy always the latest z-stream submariner version available aligned to installed ACM.