### PR TITLE
Increase waiting time for cypress deployment test

### DIFF
--- a/cypress/cypress/e2e/03_submariner_deploy.cy.js
+++ b/cypress/cypress/e2e/03_submariner_deploy.cy.js
@@ -68,7 +68,7 @@ describe('submariner - Deployment validation', {
         cy.get('button').contains('Install').click()
         cy.log('waiting for the submariner deployment to be done.')
 
-        cy.wait(350000)
+        cy.wait(650000)
         submarinerClusterSetMethods.testTheDataLabel("Gateway nodes labeled", 'Nodes labeled', 'submariner.io/gateway')
         submarinerClusterSetMethods.testTheDataLabel("Agent status", 'Healthy', 'is deployed on managed cluster')
         submarinerClusterSetMethods.testTheDataLabel("Connection status", 'Healthy', 'established')


### PR DESCRIPTION
UI Submariner deployment could take time to reach the fully connected state.
Increase the timeout to wait for that state.