### PR TITLE
Fox ROKS cluster list creation

### DIFF
--- a/lib/submariner_prepare/roks_prepare_for_submariner.sh
+++ b/lib/submariner_prepare/roks_prepare_for_submariner.sh
@@ -8,7 +8,7 @@ function create_roks_clusters_list() {
         product=$(get_cluster_product "$cluster")
 
         if [[ "$product" == "ROKS" ]]; then
-            clusters+="$cluster"
+            clusters+="$cluster,"
         fi
     done
     clusters=$(echo "${clusters%,}" | tr "," "\n")


### PR DESCRIPTION
The function for cluster list creation merges multiple roks clusters into one single line.
Fixing this by adding a comma during list creation.