### PR TITLE
Add memory to jenkins testing pod

### DIFF
--- a/jenkinsfiles/SubmarinerAgentPod.yaml
+++ b/jenkinsfiles/SubmarinerAgentPod.yaml
@@ -34,10 +34,10 @@ spec:
     resources:
       limits:
         cpu: 2000m
-        memory: 3Gi
+        memory: 4Gi
       requests:
         cpu: 2000m
-        memory: 3Gi
+        memory: 4Gi
     volumeMounts:
       - name: skynet-data
         mountPath: '/var/skynet-data'


### PR DESCRIPTION
In the newer versions, cypress started to fail during the testing. Adding memory to resolve it.