### PR TITLE
Modify the location of cypress videos and snapshot

### DIFF
--- a/jenkinsfiles/SubmarinerAgentPod.yaml
+++ b/jenkinsfiles/SubmarinerAgentPod.yaml
@@ -34,10 +34,10 @@ spec:
     resources:
       limits:
         cpu: 2000m
-        memory: 3Gi
+        memory: 4Gi
       requests:
         cpu: 2000m
-        memory: 3Gi
+        memory: 4Gi
     volumeMounts:
       - name: skynet-data
         mountPath: '/var/skynet-data'

--- a/jenkinsfiles/SubmarinerAgentPod.yaml
+++ b/jenkinsfiles/SubmarinerAgentPod.yaml
@@ -34,10 +34,10 @@ spec:
     resources:
       limits:
         cpu: 2000m
-        memory: 4Gi
+        memory: 3Gi
       requests:
         cpu: 2000m
-        memory: 4Gi
+        memory: 3Gi
     volumeMounts:
       - name: skynet-data
         mountPath: '/var/skynet-data'

--- a/lib/submariner_test/submariner_ui.sh
+++ b/lib/submariner_test/submariner_ui.sh
@@ -27,12 +27,16 @@ function execute_submariner_ui_tests() {
 
     export CYPRESS_LOGS_PATH="$TESTS_LOGS_UI"
 
-    npx cypress run --browser "$TEST_BROWSER" --headless --env grepFilterSpecs=true,grepTags=@e2e || true
+    npx cypress run --browser "$TEST_BROWSER" \
+        --config screenshotsFolder="${TESTS_LOGS_UI}/results/screenshots,videosFolder=${TESTS_LOGS_UI}/results/videos" \
+        --headless --env grepFilterSpecs=true,grepTags=@e2e || true
 
     INFO "Combine cypress reports"
     npx jrm "$TESTS_LOGS_UI/${tests_basename}_junit.xml" results/test-results-*.xml
 
     popd || return
+
+    tar -czf "$TESTS_LOGS_UI/cypress_results.tar.gz" --remove-files -C "$TESTS_LOGS_UI" results
 
     # Restore submariner deployment in case it was deleted by one of the tests
     subm_state=$(oc -n "$primary_cluster" get managedclusteraddon submariner \


### PR DESCRIPTION
Modify the location of cypress videos and snapshot
    
- Modify the cypress execution command to place the tests generated
   videos and snapshots into logs tests directory.
- Add command to archive the directory of videos and snapshots of
  cypress within logs tests directory.