### PR TITLE
Fix submariner version fetch

### DIFF
--- a/lib/common/helper_functions.sh
+++ b/lib/common/helper_functions.sh
@@ -365,7 +365,7 @@ function fetch_installed_submariner_version() {
     fi
 
     subm_ver=$(KUBECONFIG="$KCONF/$primary_cl-kubeconfig.yaml" \
-        oc -n "$SUBMARINER_NS" get submariner submariner -o jsonpath='{.status.version}' \
+        oc -n "$SUBMARINER_NS" get submariner submariner -o jsonpath='{.status.gateways[].version}' \
         | grep -Po '(?<=v)[^)]*')
     echo "$subm_ver"
 }


### PR DESCRIPTION
During upgrade flow, submariner version fetched.
In version 0.15, the structure of submariner version value different from the newer version.
Align the structure to be able to fetc hthe version successfully.